### PR TITLE
ci: verify pull requests with proof-pr

### DIFF
--- a/.github/proof-pr/expected-failure.toml
+++ b/.github/proof-pr/expected-failure.toml
@@ -1,0 +1,7 @@
+[verify]
+base = "master"
+timeout = 60
+
+[[verify.checks]]
+name = "intentional-failure"
+command = ["python3", "-c", "raise SystemExit(9)"]

--- a/.github/workflows/proof-pr.yml
+++ b/.github/workflows/proof-pr.yml
@@ -1,0 +1,63 @@
+name: proof-pr
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify commit-bound evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: HsiangNianian/proof-pr@v0.1.0
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+
+  rejection-contract:
+    name: Reject failed evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Exercise a failing verification
+        id: proof
+        continue-on-error: true
+        uses: HsiangNianian/proof-pr@v0.1.0
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          config: .github/proof-pr/expected-failure.toml
+          output-dir: .proof-pr/expected-failure
+
+      - name: Confirm the failure was enforced
+        shell: bash
+        env:
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          PROOF_OUTCOME: ${{ steps.proof.outcome }}
+          PROOF_VERDICT: ${{ steps.proof.outputs.verdict }}
+          REPORT_PATH: ${{ steps.proof.outputs.report-json }}
+        run: |
+          test "$PROOF_OUTCOME" = "failure"
+          test "$PROOF_VERDICT" = "FAILED"
+          test "$REPORT_PATH" = ".proof-pr/expected-failure/report.json"
+          python - "$REPORT_PATH" "$EXPECTED_HEAD" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          report = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          assert report["verdict"] == "FAILED"
+          assert report["head_sha"] == sys.argv[2]
+          assert report["checks"][0]["exit_code"] == 9
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pip-log.txt
 pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+.proof-pr/
 htmlcov/
 .tox/
 .nox/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![crates.io](https://img.shields.io/crates/v/soon.svg)](https://crates.io/crates/soon)
 [![PyPI](https://img.shields.io/pypi/v/soon-bin.svg)](https://pypi.org/project/soon-bin/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![proof-pr](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml/badge.svg)](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml)
 [![Publish to crates.io](https://github.com/HsiangNianian/soon/actions/workflows/publish-crates.yml/badge.svg)](https://github.com/HsiangNianian/soon/actions/workflows/publish-crates.yml)
 [![Publish to PyPI](https://github.com/HsiangNianian/soon/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/HsiangNianian/soon/actions/workflows/publish-pypi.yml)
 

--- a/proof-pr.toml
+++ b/proof-pr.toml
@@ -1,0 +1,15 @@
+[verify]
+base = "master"
+timeout = 900
+
+[[verify.checks]]
+name = "cargo-check"
+command = ["cargo", "check", "--locked"]
+
+[[verify.checks]]
+name = "cargo-test"
+command = ["cargo", "test", "--locked"]
+
+[[verify.checks]]
+name = "cli-smoke"
+command = ["cargo", "run", "--locked", "--", "--version"]


### PR DESCRIPTION
## Why

Use `soon` as the first real repository consuming `HsiangNianian/proof-pr@v0.1.0`, so commit-bound verification is exercised outside the action's own repository.

## What changed

- add repository checks for `cargo check`, `cargo test`, and a CLI version smoke test
- verify pull requests with a read-only token and the exact PR head/base commits
- exercise an intentional failure and assert that proof-pr reports `FAILED` and rejects the evidence
- ignore generated evidence and expose the workflow status in the README

## Local evidence

- normal config: `VERIFIED` with all three checks passing
- rejection config: intentional exit code `9`, report verdict `FAILED`
- both `verify` and `status` returned non-zero for the failed evidence

Once hosted checks pass, this PR will be the external-use evidence for proof-pr's Marketplace readiness.

## Summary by Sourcery

为拉取请求添加基于 proof-pr 的验证机制，并在 README 中记录其状态。

CI：
- 引入一个 `proof-pr` GitHub Actions 工作流，使用 `cargo check`、测试以及 CLI 冒烟测试来验证拉取请求提交。
- 添加一个 CI 任务，刻意运行一个会失败的 `proof-pr` 验证，并断言该失败会被正确报告并拒绝。

文档：
- 在 README 中添加一个徽章，展示 `proof-pr` 验证工作流的状态。

杂项：
- 添加 `proof-pr` 配置文件，用于定义验证检查以及一个预期失败的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add proof-pr-based verification for pull requests and document its status in the README.

CI:
- Introduce a proof-pr GitHub Actions workflow that verifies pull request commits using cargo check, tests, and a CLI smoke test.
- Add a CI job that deliberately exercises a failing proof-pr verification and asserts the failure is correctly reported and rejected.

Documentation:
- Add a README badge exposing the status of the proof-pr verification workflow.

Chores:
- Add proof-pr configuration files defining the verification checks and an expected-failure scenario.

</details>