### PR TITLE
fix(deps): update Pygments to 2.20.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -25,11 +25,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update the transitive Pygments dependency from 2.19.1 to 2.20.0
- keep the existing package index and every unrelated lock entry unchanged
- resolve the GUID lexer ReDoS alert fixed in Pygments 2.20.0

## Validation

- `uv lock --check --default-index https://mirrors.aliyun.com/pypi/simple`
- `uv sync --locked --default-index https://mirrors.aliyun.com/pypi/simple`
- imported `pygments.__version__` is `2.20.0`
- `uvx pre-commit run --all-files`

## Summary by Sourcery

将锁定的 Pygments 依赖版本更新为 2.20.0，以获取上游对 GUID 词法分析器 ReDoS 问题的修复，同时保持其他无关的锁定条目不变。

Bug Fixes:
- 通过将 Pygments 升级到已修复的 2.20.0 版本来解决 GUID 词法分析器的 ReDoS 漏洞。

Build:
- 重新生成 uv 锁定文件，使其反映 Pygments 2.20.0 的依赖版本，同时不修改其他软件包索引设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the locked Pygments dependency version to 2.20.0 to pick up the upstream GUID lexer ReDoS fix while leaving unrelated lock entries unchanged.

Bug Fixes:
- Address the GUID lexer ReDoS vulnerability by upgrading Pygments to the fixed 2.20.0 release.

Build:
- Regenerate the uv lockfile to reflect the Pygments 2.20.0 dependency version without modifying other package index settings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将锁定的 Pygments 依赖版本更新为 2.20.0，以获取上游对 GUID 词法分析器 ReDoS 问题的修复，同时保持其他无关的锁定条目不变。

Bug Fixes:
- 通过将 Pygments 升级到已修复的 2.20.0 版本来解决 GUID 词法分析器的 ReDoS 漏洞。

Build:
- 重新生成 uv 锁定文件，使其反映 Pygments 2.20.0 的依赖版本，同时不修改其他软件包索引设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the locked Pygments dependency version to 2.20.0 to pick up the upstream GUID lexer ReDoS fix while leaving unrelated lock entries unchanged.

Bug Fixes:
- Address the GUID lexer ReDoS vulnerability by upgrading Pygments to the fixed 2.20.0 release.

Build:
- Regenerate the uv lockfile to reflect the Pygments 2.20.0 dependency version without modifying other package index settings.

</details>

</details>