### PR TITLE
feat: add Zsh ghost suggestions

### DIFF
--- a/.github/workflows/proof-pr.yml
+++ b/.github/workflows/proof-pr.yml
@@ -17,6 +17,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install Zsh for the interactive shell harness
+        run: sudo apt-get update && sudo apt-get install --yes zsh
+
       - uses: HsiangNianian/proof-pr@v0.1.0
         with:
           base: ${{ github.event.pull_request.base.sha }}

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The last background prediction latency is available without printing command con
 print -r -- "$SOON_LAST_LATENCY_MS ms"
 ```
 
-PyPI and AUR distribution are being reconciled as part of the [v0.4 release issue](https://github.com/HsiangNianian/soon/issues/12) and are not advertised as primary channels for this prototype.
+PyPI and AUR distributions are being reconciled as part of the [v0.4 release issue](https://github.com/HsiangNianian/soon/issues/12) and are not advertised as primary channels for this prototype.
 
 ## Use the current prototype
 
@@ -129,7 +129,7 @@ This baseline is deliberately simple. A more complex ranker must beat it on the 
 
 `soon`, `soon now`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
 
-The current integration honors configured ignored executables and refuses multiline/control-character output, but the broader sensitive-command filter tracked in [#9](https://github.com/HsiangNianian/soon/issues/9) is not shipped yet. Treat this source build as a prototype on histories that may contain inline credentials.
+The current integration honors configured ignored executables and refuses multiline/control-character output, but the broader sensitive-command filter tracked in [#9](https://github.com/HsiangNianian/soon/issues/9) is not shipped yet. Treat this source build as a prototype for histories that may contain inline credentials.
 
 `soon learn ask` is different: it is an optional experimental path that sends recent command context, the current directory, and time context to the OpenAI-compatible or Ollama endpoint you configure. API credentials are currently stored in the local config file. Do not enable remote enrichment for sensitive histories; safer capture, filtering, and credential guidance are tracked in [#9](https://github.com/HsiangNianian/soon/issues/9).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A local-first experiment that learns recurring shell transitions and predicts th
 
 </div>
 
-> **Prototype status:** the current source predicts a full command on demand. Automatic, zero-input Zsh suggestions are the goal of the [v0.4 milestone](https://github.com/HsiangNianian/soon/milestone/1), not a shipped feature yet.
+> **Prototype status:** the current source includes the first opt-in Zsh ghost-suggestion loop. The published `0.3.0` package still exposes only on-demand prediction; install from Git to test the interactive path before the [v0.4 beta](https://github.com/HsiangNianian/soon/milestone/1).
 
 ## The idea
 
@@ -58,6 +58,26 @@ To try the current repository behavior before the next release:
 cargo install --git https://github.com/HsiangNianian/soon
 ```
 
+Enable the integration for the current Zsh session:
+
+```zsh
+eval "$(soon init zsh)"
+```
+
+At an empty prompt, soon computes in the background and renders one dim full-command suggestion. Press `Ctrl-F` to place it in the editable buffer, or start typing to ignore it. `Ctrl-F` keeps its previous behavior when no suggestion is visible.
+
+To enable it in future sessions, add the same `eval` line to `~/.zshrc`. To remove the hooks and restore the previous `Ctrl-F` binding in the current session, run:
+
+```zsh
+soon-disable
+```
+
+The last background prediction latency is available without printing command content:
+
+```zsh
+print -r -- "$SOON_LAST_LATENCY_MS ms"
+```
+
 PyPI and AUR distribution are being reconciled as part of the [v0.4 release issue](https://github.com/HsiangNianian/soon/issues/12) and are not advertised as primary channels for this prototype.
 
 ## Use the current prototype
@@ -88,11 +108,10 @@ The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and t
 
 | Current source | v0.4 target |
 |---|---|
-| On-demand `soon` command | Empty-prompt Zsh ghost suggestion |
-| Full-command candidates from local history | One-key acceptance without disrupting shell editing |
-| Deterministic frequency and recency ranking | Working-directory and exit-status context |
-| Local config and diagnostics | Sensitive-command filtering, inspect, and clear controls |
-| Experimental learned and LLM subcommands | Local replay metrics and a measured latency budget |
+| On-demand command plus opt-in Zsh loop | Coherent beta install and clean-session smoke test |
+| Background ghost suggestion with `Ctrl-F` acceptance | Contextual events with directory and exit status |
+| Deterministic frequency and recency ranking | Sensitive-command filtering, inspect, and clear controls |
+| Local config plus experimental learning tools | Local replay metrics and a measured latency budget |
 
 The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). Work is tracked in the public [Predictive Shell Project](https://github.com/users/HsiangNianian/projects/7).
 
@@ -108,7 +127,9 @@ This baseline is deliberately simple. A more complex ranker must beat it on the 
 
 ## Privacy
 
-`soon`, `soon now`, `soon which`, and the local learning commands read files on your machine and do not require a network service.
+`soon`, `soon now`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
+
+The current integration honors configured ignored executables and refuses multiline/control-character output, but the broader sensitive-command filter tracked in [#9](https://github.com/HsiangNianian/soon/issues/9) is not shipped yet. Treat this source build as a prototype on histories that may contain inline credentials.
 
 `soon learn ask` is different: it is an optional experimental path that sends recent command context, the current directory, and time context to the OpenAI-compatible or Ollama endpoint you configure. API credentials are currently stored in the local config file. Do not enable remote enrichment for sensitive histories; safer capture, filtering, and credential guidance are tracked in [#9](https://github.com/HsiangNianian/soon/issues/9).
 
@@ -126,6 +147,7 @@ soon config set general.ngram 5
 ```text
 soon                    Predict the next full command
 soon now                Run the same prediction explicitly
+soon init zsh           Print the opt-in Zsh integration
 soon stats              Show the most-used executables
 soon which              Show shell and history diagnostics
 soon config             View or change local configuration

--- a/proof-pr.toml
+++ b/proof-pr.toml
@@ -15,6 +15,10 @@ name = "cargo-test"
 command = ["cargo", "test", "--locked"]
 
 [[verify.checks]]
+name = "zsh-integration"
+command = ["zsh", "tests/zsh_integration.zsh", "target/debug/soon"]
+
+[[verify.checks]]
 name = "cargo-clippy"
 command = ["cargo", "clippy", "--locked", "--all-targets", "--", "-D", "warnings"]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -19,8 +19,20 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Print shell integration code for the current session
+    Init {
+        #[arg(value_enum)]
+        shell: InitShell,
+    },
     /// Show the most likely next command
-    Now,
+    Now {
+        /// Print only the predicted command
+        #[arg(long)]
+        raw: bool,
+        /// Include the command that just started in the prediction context
+        #[arg(long, hide = true, requires = "raw")]
+        after: Option<String>,
+    },
     /// Show most used commands
     Stats,
     /// Learn from command history and predict intelligently
@@ -37,6 +49,11 @@ pub enum Commands {
         #[command(subcommand)]
         action: Option<ConfigAction>,
     },
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+pub enum InitShell {
+    Zsh,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,8 @@
+use crate::cli::InitShell;
+use crate::shell;
+
+pub fn run(shell: InitShell) {
+    match shell {
+        InitShell::Zsh => print!("{}", shell::zsh::integration_script()),
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod init;
 pub mod learn;
 pub mod now;
 pub mod stats;

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -5,10 +5,16 @@ use crate::cache;
 use crate::config::AppConfig;
 use crate::learn::{self, db::LearnDb, pattern};
 use crate::predict::{self, main_cmd};
-use crate::shell::{self, ShellKind};
+use crate::shell::{self, HistoryItem, ShellKind};
 
-pub fn run(shell: &ShellKind, ngram: usize, config: &AppConfig, debug: bool) {
-    cache::overwrite_soon_cache_from_history(shell, ngram);
+pub fn run(
+    shell: &ShellKind,
+    ngram: usize,
+    config: &AppConfig,
+    debug: bool,
+    raw: bool,
+    after: Option<&str>,
+) {
     let history = shell::load_history(shell);
     if history.is_empty() {
         eprintln!(
@@ -18,8 +24,21 @@ pub fn run(shell: &ShellKind, ngram: usize, config: &AppConfig, debug: bool) {
         std::process::exit(1);
     }
 
-    let cache_cmds = cache::read_soon_cache(ngram);
-    let suggestion = predict::predict_next_command(&history, ngram, &cache_cmds, config, debug);
+    let cache_cmds = if raw {
+        recent_context(&history, ngram, after)
+    } else {
+        cache::overwrite_soon_cache_from_history(shell, ngram);
+        cache::read_soon_cache(ngram)
+    };
+    let suggestion =
+        predict::predict_next_command(&history, ngram, &cache_cmds, config, debug && !raw);
+
+    if raw {
+        if let Some(cmd) = suggestion.filter(|cmd| !cmd.chars().any(char::is_control)) {
+            println!("{cmd}");
+        }
+        return;
+    }
 
     println!("\n{}", "You might run next:".magenta().bold());
     match suggestion {
@@ -76,4 +95,24 @@ pub fn run(shell: &ShellKind, ngram: usize, config: &AppConfig, debug: bool) {
             }
         }
     }
+}
+
+fn recent_context(history: &[HistoryItem], ngram: usize, after: Option<&str>) -> Vec<String> {
+    let context_len = ngram.max(1);
+    let history_len = context_len.saturating_sub(usize::from(after.is_some()));
+    let mut commands: Vec<String> = history
+        .iter()
+        .rev()
+        .take(history_len)
+        .map(|item| main_cmd(&item.cmd).to_string())
+        .collect();
+    commands.reverse();
+
+    if let Some(command) = after {
+        commands.push(main_cmd(command).to_string());
+    }
+
+    commands.retain(|command| !command.is_empty());
+    commands.dedup();
+    commands
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
     let ngram = cli.ngram.unwrap_or(config.general.ngram);
 
     match cli.command {
+        Some(Commands::Init { shell }) => commands::init::run(shell),
         Some(Commands::Config { action }) => commands::config::run(action),
         Some(Commands::Update) => commands::update::run(&config),
         Some(Commands::Learn { action }) => {
@@ -42,9 +43,13 @@ fn main() {
             require_known_shell(&shell);
             commands::stats::run(&shell, &config);
         }
-        Some(Commands::Now) | None => {
+        Some(Commands::Now { raw, after }) => {
             require_known_shell(&shell);
-            commands::now::run(&shell, ngram, &config, cli.debug);
+            commands::now::run(&shell, ngram, &config, cli.debug, raw, after.as_deref());
+        }
+        None => {
+            require_known_shell(&shell);
+            commands::now::run(&shell, ngram, &config, cli.debug, false, None);
         }
     }
 }

--- a/src/shell/soon.zsh
+++ b/src/shell/soon.zsh
@@ -1,0 +1,147 @@
+if [[ -o interactive ]]; then
+  zmodload zsh/zle
+  zmodload zsh/datetime
+  autoload -Uz add-zle-hook-widget
+  autoload -Uz add-zsh-hook
+
+  if (( $+functions[_soon_teardown] )); then
+    _soon_teardown
+  fi
+
+  typeset -g _soon_suggestion=''
+  typeset -g _soon_highlight=''
+  typeset -gi _soon_fd=-1
+  typeset -g SOON_LAST_LATENCY_MS=''
+  typeset -g _soon_previous_ctrl_f=${${(z)$(bindkey '^F' 2>/dev/null)}[-1]}
+  [[ -n $_soon_previous_ctrl_f ]] || _soon_previous_ctrl_f='.forward-char'
+
+  function _soon_remove_highlight() {
+    local entry
+    local -a kept=()
+    local -i removed=0
+    for entry in "${region_highlight[@]}"; do
+      if (( ! removed )) && [[ -n $_soon_highlight && $entry == $_soon_highlight ]]; then
+        removed=1
+      else
+        kept+=("$entry")
+      fi
+    done
+    region_highlight=("${kept[@]}")
+    _soon_highlight=''
+  }
+
+  function _soon_refresh_display() {
+    _soon_remove_highlight
+    POSTDISPLAY=''
+
+    if [[ -z $BUFFER && -n $_soon_suggestion ]]; then
+      POSTDISPLAY=$_soon_suggestion
+      _soon_highlight="0 ${#POSTDISPLAY} fg=8"
+      region_highlight+=("$_soon_highlight")
+    fi
+  }
+
+  function _soon_apply_suggestion() {
+    _soon_refresh_display
+    zle -R
+  }
+
+  function _soon_cancel_prediction() {
+    if (( _soon_fd >= 0 )); then
+      zle -F $_soon_fd 2>/dev/null || true
+      exec {_soon_fd}<&-
+      _soon_fd=-1
+    fi
+  }
+
+  function _soon_prediction_ready() {
+    local fd=$1
+    local line=''
+
+    if IFS= read -r line <&$fd && [[ $line == *$'\t'* ]]; then
+      SOON_LAST_LATENCY_MS=${line%%$'\t'*}
+      _soon_suggestion=${line#*$'\t'}
+    else
+      _soon_suggestion=''
+    fi
+    zle -F $fd 2>/dev/null || true
+    (( fd == _soon_fd )) && _soon_fd=-1
+    exec {fd}<&-
+    zle _soon_apply_suggestion
+  }
+
+  function _soon_start_prediction() {
+    local after=${1:-}
+    local started=$EPOCHREALTIME
+    _soon_cancel_prediction
+    _soon_suggestion=''
+
+    if [[ -n $after ]]; then
+      exec {_soon_fd}< <(
+        local suggestion elapsed
+        suggestion=$(command soon --shell zsh --ngram 1 now --raw --after "$after" 2>/dev/null)
+        elapsed=$(( (EPOCHREALTIME - started) * 1000.0 ))
+        printf '%.3f\t%s\n' $elapsed "$suggestion"
+      )
+    else
+      exec {_soon_fd}< <(
+        local suggestion elapsed
+        suggestion=$(command soon --shell zsh now --raw 2>/dev/null)
+        elapsed=$(( (EPOCHREALTIME - started) * 1000.0 ))
+        printf '%.3f\t%s\n' $elapsed "$suggestion"
+      )
+    fi
+
+    zle -F $_soon_fd _soon_prediction_ready
+  }
+
+  function _soon_line_init() {
+    (( _soon_fd >= 0 )) || _soon_start_prediction
+    _soon_refresh_display
+    return 0
+  }
+
+  function _soon_line_pre_redraw() {
+    _soon_refresh_display
+    return 0
+  }
+
+  function _soon_preexec() {
+    _soon_start_prediction "$1"
+    return 0
+  }
+
+  function _soon_accept() {
+    if [[ -z $BUFFER && -n $_soon_suggestion ]]; then
+      BUFFER=$_soon_suggestion
+      CURSOR=${#BUFFER}
+      _soon_suggestion=''
+      _soon_refresh_display
+    else
+      zle "$_soon_previous_ctrl_f"
+    fi
+  }
+
+  function _soon_teardown() {
+    _soon_cancel_prediction
+    add-zle-hook-widget -d line-init _soon_line_init 2>/dev/null || true
+    add-zle-hook-widget -d line-pre-redraw _soon_line_pre_redraw 2>/dev/null || true
+    add-zsh-hook -d preexec _soon_preexec 2>/dev/null || true
+    bindkey '^F' "$_soon_previous_ctrl_f"
+    zle -D _soon_accept 2>/dev/null || true
+    zle -D _soon_apply_suggestion 2>/dev/null || true
+    _soon_suggestion=''
+    _soon_highlight=''
+  }
+
+  function soon-disable() {
+    _soon_teardown
+  }
+
+  zle -N _soon_accept
+  zle -N _soon_apply_suggestion
+  add-zle-hook-widget line-init _soon_line_init
+  add-zle-hook-widget line-pre-redraw _soon_line_pre_redraw
+  add-zsh-hook preexec _soon_preexec
+  bindkey '^F' _soon_accept
+fi

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -2,6 +2,10 @@ use std::io::{BufRead, Read};
 
 use super::HistoryItem;
 
+pub fn integration_script() -> &'static str {
+    include_str!("soon.zsh")
+}
+
 pub fn parse_zsh_history<R: Read>(reader: std::io::BufReader<R>, result: &mut Vec<HistoryItem>) {
     for line in reader.lines().map_while(Result::ok) {
         let line = line.trim().to_string();

--- a/tests/zsh_cli.rs
+++ b/tests/zsh_cli.rs
@@ -1,0 +1,87 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn isolated_home() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("soon-zsh-test-{}-{nonce}", std::process::id()));
+    std::fs::create_dir_all(&path).expect("create isolated home");
+    path
+}
+
+#[test]
+fn init_zsh_prints_a_sourceable_script_without_noise() {
+    let output = Command::new(env!("CARGO_BIN_EXE_soon"))
+        .args(["init", "zsh"])
+        .output()
+        .expect("run soon init zsh");
+
+    assert!(
+        output.status.success(),
+        "soon init zsh failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!output.stdout.is_empty(), "integration script was empty");
+
+    let Ok(mut zsh) = Command::new("zsh")
+        .arg("-n")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    else {
+        return;
+    };
+    zsh.stdin
+        .take()
+        .expect("zsh stdin")
+        .write_all(&output.stdout)
+        .expect("write integration script to zsh");
+    let syntax = zsh.wait_with_output().expect("check Zsh syntax");
+
+    assert!(
+        syntax.status.success(),
+        "invalid Zsh integration: {}",
+        String::from_utf8_lossy(&syntax.stderr)
+    );
+}
+
+#[test]
+fn raw_prediction_uses_the_submitted_command_as_context() {
+    let home = isolated_home();
+    std::fs::write(
+        home.join(".zsh_history"),
+        "git status\ncargo test --workspace\necho break\ngit diff\ncargo test --workspace\n",
+    )
+    .expect("write Zsh history");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soon"))
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .args([
+            "--shell", "zsh", "--ngram", "1", "now", "--raw", "--after", "git log",
+        ])
+        .output()
+        .expect("run raw prediction");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        output.status.success(),
+        "raw prediction failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty(), "raw prediction wrote diagnostics");
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 prediction"),
+        "cargo test --workspace\n"
+    );
+}

--- a/tests/zsh_integration.zsh
+++ b/tests/zsh_integration.zsh
@@ -1,0 +1,145 @@
+#!/usr/bin/env zsh
+
+emulate -LR zsh
+setopt err_return pipe_fail
+zmodload zsh/datetime
+zmodload zsh/zpty
+
+local soon_bin=${1:-target/debug/soon}
+if [[ ! -x $soon_bin ]]; then
+  cargo build --locked
+fi
+soon_bin=${soon_bin:A}
+
+local test_root=${TMPDIR:-/tmp}/soon-zsh-harness-$$
+local fake_bin=$test_root/bin
+local integration_file=$test_root/integration.zsh
+local accepted_file=/tmp/soon-zsh-accept-$$
+mkdir -p $fake_bin
+
+function cleanup() {
+  zpty -d soon_shell 2>/dev/null || true
+  rm -f $accepted_file
+  rm -rf $test_root
+}
+trap cleanup EXIT INT TERM HUP
+
+$soon_bin init zsh > $integration_file
+
+cat > $fake_bin/soon <<FAKE_SOON
+#!/bin/sh
+sleep 0.05
+printf '%s\n' 'touch $accepted_file'
+FAKE_SOON
+chmod +x $fake_bin/soon
+
+cat > $test_root/.zshrc <<ZSHRC
+stty 38400 columns 120 rows 24 tabs -icanon -iexten
+function _soon_harness_tc() { REPLY=''; }
+zle -T tc _soon_harness_tc
+function _soon_harness_previous_ctrl_f() {
+  BUFFER+='ORIGINAL_CTRL_F'
+  CURSOR=\${#BUFFER}
+}
+zle -N _soon_harness_previous_ctrl_f
+bindkey '^F' _soon_harness_previous_ctrl_f
+PS1='SOON_PROMPT> '
+RPROMPT=''
+source ${(q)integration_file}
+ZSHRC
+
+local shell_path=$fake_bin:$PATH
+zpty soon_shell env PATH=${(q)shell_path} ZDOTDIR=${(q)test_root} HOME=${(q)test_root} TERM=xterm-256color zsh -d -i
+
+typeset -g transcript=''
+
+function wait_for_output() {
+  local needle=$1
+  local timeout=${2:-5}
+  local chunk=''
+  local -F deadline=$(( EPOCHREALTIME + timeout ))
+
+  while (( EPOCHREALTIME < deadline )); do
+    if zpty -r -t soon_shell chunk; then
+      transcript+=$chunk
+      if [[ $transcript == *$needle* ]]; then
+        return 0
+      fi
+    fi
+    sleep 0.02
+  done
+
+  print -u2 -- "timed out waiting for: $needle"
+  print -u2 -- "transcript: ${(qqq)transcript}"
+  return 1
+}
+
+function wait_for_file() {
+  local target_file=$1
+  local -F deadline=$(( EPOCHREALTIME + 5 ))
+  local progress_chunk=''
+
+  while (( EPOCHREALTIME < deadline )); do
+    [[ -e $target_file ]] && return 0
+    if zpty -r -t soon_shell progress_chunk; then
+      transcript+=$progress_chunk
+    fi
+    sleep 0.02
+  done
+
+  print -u2 -- "timed out waiting for file: $target_file"
+  local failure_chunk=''
+  local failure_output=''
+  while zpty -r -t soon_shell failure_chunk; do
+    failure_output+=$failure_chunk
+  done
+  print -u2 -- "shell output: ${(qqq)failure_output}"
+  return 1
+}
+
+# Render and accept a suggestion at an empty prompt.
+wait_for_output 'SOON_PROMPT> '
+transcript=''
+wait_for_output "touch $accepted_file"
+transcript=''
+zpty -w -n soon_shell $'\x06'
+sleep 0.05
+zpty -w -n soon_shell $'\n'
+wait_for_file $accepted_file
+wait_for_output 'SOON_PROMPT> '
+
+# Normal typing ignores the ghost suggestion instead of modifying the buffer.
+rm -f $accepted_file
+transcript=''
+wait_for_output "touch $accepted_file"
+transcript=''
+zpty -w soon_shell '[[ $SOON_LAST_LATENCY_MS == <->.<-> ]] && print -r -- SOON_TYPED_NORMALLY'
+wait_for_output 'SOON_TYPED_NORMALLY'
+wait_for_output 'SOON_PROMPT> '
+[[ ! -e $accepted_file ]] || {
+  print -u2 -- 'typing a command unexpectedly accepted the suggestion'
+  return 1
+}
+
+# Teardown removes hooks and cancels pending prediction work.
+transcript=''
+zpty -w soon_shell 'soon-disable'
+wait_for_output 'SOON_PROMPT> '
+transcript=''
+sleep 0.2
+local chunk=''
+while zpty -r -t soon_shell chunk; do
+  transcript+=$chunk
+done
+[[ $transcript != *"touch $accepted_file"* ]] || {
+  print -u2 -- 'suggestion rendered after soon-disable'
+  return 1
+}
+
+transcript=''
+zpty -w -n soon_shell $'\x06'
+wait_for_output 'ORIGINAL_CTRL_F'
+zpty -w -n soon_shell $'\x15'
+
+zpty -w soon_shell 'exit'
+print -- 'Zsh integration harness passed'


### PR DESCRIPTION
## Summary

- add `soon init zsh` for an opt-in, current-session ZLE integration
- predict in a background process and render only at an empty editable buffer
- accept with `Ctrl-F`, delegate to the previous binding otherwise, and restore it with `soon-disable`
- expose the last local prediction time through `SOON_LAST_LATENCY_MS`
- add CLI tests plus a real PTY harness for render, accept, ignore, latency, and teardown
- document the source-only prototype and add the harness to commit-bound CI

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo test --locked` (6 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `uvx pre-commit run --all-files`
- `cargo package --locked --allow-dirty --list`

Closes #7
Refs #4

## Summary by Sourcery

引入可选启用的 Zsh 幽灵建议（ghost suggestion）集成，并扩展 CLI，以支持在 Zsh shell 中的会话初始化和原始预测输出。

New Features:
- 添加 `soon init zsh` 子命令，为当前会话打印可被 `source` 的 Zsh 集成脚本。
- 实现 Zsh 幽灵建议循环：在后台进行预测，在空提示符渲染建议，并通过 `SOON_LAST_LATENCY_MS` 暴露延迟。
- 扩展 `soon now`，加入原始输出模式以及可选的 `after` 上下文参数，用于非交互式预测流程。

Enhancements:
- 调整 `soon now` 命令，在生成预测时复用最近历史记录和已提交命令上下文，并避免打印控制字符。
- 更新 README，记录 Zsh 集成方式、其可选启用行为、延迟报告机制，以及修订后的原型路线图和隐私说明。
- 明确 CLI 帮助和命令列表，将新的 `soon init zsh` 集成命令包含在内。

CI:
- 更新 proof-pr 工作流及配置，安装 Zsh，并在 PR 验证过程中运行新的 Zsh 集成测试挂件。

Tests:
- 添加基于 PTY 的 Zsh 测试脚本，用于验证幽灵建议集成的渲染、接受、忽略、延迟报告以及拆卸流程。
- 新增 CLI 测试，用于验证 `soon init zsh` 输出语法，以及在显式 `after` 上下文下的原始预测行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an opt-in Zsh ghost suggestion integration and extend the CLI to support session initialization and raw prediction output for Zsh shells.

New Features:
- Add a `soon init zsh` subcommand that prints a sourceable Zsh integration script for the current session.
- Implement a Zsh ghost suggestion loop that predicts in the background, renders suggestions at an empty prompt, and exposes latency via `SOON_LAST_LATENCY_MS`.
- Extend `soon now` with a raw output mode and an optional `after` context argument for non-interactive prediction flows.

Enhancements:
- Adjust the `soon now` command to reuse recent history and submitted command context when generating predictions and to avoid printing control characters.
- Update README to document the Zsh integration, its opt-in behavior, latency reporting, and revised prototype roadmap and privacy notes.
- Clarify the CLI help and command list to include the new `soon init zsh` integration command.

CI:
- Update the proof-pr workflow and configuration to install Zsh and run the new Zsh integration harness as part of PR verification.

Tests:
- Add a PTY-based Zsh harness script to verify rendering, acceptance, ignoring, latency reporting, and teardown of the ghost suggestion integration.
- Introduce CLI tests to validate `soon init zsh` output syntax and raw prediction behavior with an explicit `after` context.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入可选启用的 Zsh 幽灵建议（ghost suggestion）集成，并扩展 CLI，以支持在 Zsh shell 中的会话初始化和原始预测输出。

New Features:
- 添加 `soon init zsh` 子命令，为当前会话打印可被 `source` 的 Zsh 集成脚本。
- 实现 Zsh 幽灵建议循环：在后台进行预测，在空提示符渲染建议，并通过 `SOON_LAST_LATENCY_MS` 暴露延迟。
- 扩展 `soon now`，加入原始输出模式以及可选的 `after` 上下文参数，用于非交互式预测流程。

Enhancements:
- 调整 `soon now` 命令，在生成预测时复用最近历史记录和已提交命令上下文，并避免打印控制字符。
- 更新 README，记录 Zsh 集成方式、其可选启用行为、延迟报告机制，以及修订后的原型路线图和隐私说明。
- 明确 CLI 帮助和命令列表，将新的 `soon init zsh` 集成命令包含在内。

CI:
- 更新 proof-pr 工作流及配置，安装 Zsh，并在 PR 验证过程中运行新的 Zsh 集成测试挂件。

Tests:
- 添加基于 PTY 的 Zsh 测试脚本，用于验证幽灵建议集成的渲染、接受、忽略、延迟报告以及拆卸流程。
- 新增 CLI 测试，用于验证 `soon init zsh` 输出语法，以及在显式 `after` 上下文下的原始预测行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an opt-in Zsh ghost suggestion integration and extend the CLI to support session initialization and raw prediction output for Zsh shells.

New Features:
- Add a `soon init zsh` subcommand that prints a sourceable Zsh integration script for the current session.
- Implement a Zsh ghost suggestion loop that predicts in the background, renders suggestions at an empty prompt, and exposes latency via `SOON_LAST_LATENCY_MS`.
- Extend `soon now` with a raw output mode and an optional `after` context argument for non-interactive prediction flows.

Enhancements:
- Adjust the `soon now` command to reuse recent history and submitted command context when generating predictions and to avoid printing control characters.
- Update README to document the Zsh integration, its opt-in behavior, latency reporting, and revised prototype roadmap and privacy notes.
- Clarify the CLI help and command list to include the new `soon init zsh` integration command.

CI:
- Update the proof-pr workflow and configuration to install Zsh and run the new Zsh integration harness as part of PR verification.

Tests:
- Add a PTY-based Zsh harness script to verify rendering, acceptance, ignoring, latency reporting, and teardown of the ghost suggestion integration.
- Introduce CLI tests to validate `soon init zsh` output syntax and raw prediction behavior with an explicit `after` context.

</details>

</details>