### PR TITLE
feat: drive predictions from command lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ The current integration honors configured ignored executables and refuses multil
 
 `soon learn ask` is different: it is an optional experimental path that sends recent command context, the current directory, and time context to the OpenAI-compatible or Ollama endpoint you configure. API credentials are currently stored in the local config file. Do not enable remote enrichment for sensitive histories; safer capture, filtering, and credential guidance are tracked in [#9](https://github.com/HsiangNianian/soon/issues/9).
 
+The Zsh lifecycle integration stores local command and suggestion events in a retained JSONL log under the operating system's application-data directory. Inspect its exact path, schema version, retention, and aggregate counts without printing command text:
+
+```bash
+soon events inspect
+```
+
+The default retention is 10,000 events. It is user-controlled, and clearing requires explicit confirmation:
+
+```bash
+soon config set events.retention 5000
+soon events clear --yes
+```
+
 Config lives at `~/.config/soon/config.toml`:
 
 ```bash
@@ -151,6 +164,7 @@ soon init zsh           Print the opt-in Zsh integration
 soon stats              Show the most-used executables
 soon which              Show shell and history diagnostics
 soon config             View or change local configuration
+soon events             Inspect or clear local agent events
 soon learn              Use the experimental learning tools
 soon update             Check the configured release channel
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,12 @@ pub enum Commands {
         /// Include the command that just started in the prediction context
         #[arg(long, hide = true, requires = "raw")]
         after: Option<String>,
+        /// Exit status of the completed command
+        #[arg(long, hide = true, requires = "after", allow_hyphen_values = true)]
+        exit_code: Option<i32>,
+        /// Working directory of the completed command
+        #[arg(long, hide = true, requires = "after")]
+        cwd: Option<String>,
     },
     /// Show most used commands
     Stats,
@@ -48,6 +54,61 @@ pub enum Commands {
     Config {
         #[command(subcommand)]
         action: Option<ConfigAction>,
+    },
+    /// Inspect or clear the local command event store
+    Events {
+        #[command(subcommand)]
+        action: EventsAction,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum EventsAction {
+    /// Show event counts, schema, retention, and storage path
+    Inspect,
+    /// Remove all locally retained command and suggestion events
+    Clear {
+        /// Confirm permanent removal
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Record one completed command event (used by shell integrations)
+    #[command(hide = true)]
+    RecordCommand {
+        #[arg(long)]
+        id: String,
+        #[arg(long)]
+        command: String,
+        #[arg(long)]
+        cwd: String,
+        #[arg(long)]
+        started_at_ms: i64,
+        #[arg(long)]
+        duration_ms: u64,
+        #[arg(long, allow_hyphen_values = true)]
+        exit_code: i32,
+        #[arg(long)]
+        shell: String,
+        #[arg(long)]
+        previous_id: Option<String>,
+    },
+    /// Record one suggestion feedback event (used by shell integrations)
+    #[command(hide = true)]
+    RecordSuggestion {
+        #[arg(long)]
+        id: String,
+        #[arg(long)]
+        command_event_id: Option<String>,
+        #[arg(long)]
+        trigger: String,
+        #[arg(long)]
+        candidate_source: String,
+        #[arg(long)]
+        command: String,
+        #[arg(long)]
+        outcome: String,
+        #[arg(long)]
+        latency_ms: f64,
     },
 }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -74,6 +74,7 @@ fn get_value(key: &str) {
             eprintln!("\n{}", "Available keys:".dimmed());
             eprintln!("  general.shell, general.ngram, general.ignored_commands");
             eprintln!("  update.channel");
+            eprintln!("  events.retention");
             eprintln!("  llm.provider, llm.api_url, llm.api_key, llm.model, llm.prompt");
             std::process::exit(1);
         }

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,0 +1,100 @@
+use crate::cli::EventsAction;
+use crate::config::AppConfig;
+use crate::events::{self, CommandEvent, SuggestionEvent, SuggestionOutcome, SCHEMA_VERSION};
+
+pub fn run(action: EventsAction, config: &AppConfig) {
+    match action {
+        EventsAction::Inspect => inspect(config.events.retention),
+        EventsAction::Clear { yes } => clear(yes),
+        EventsAction::RecordCommand {
+            id,
+            command,
+            cwd,
+            started_at_ms,
+            duration_ms,
+            exit_code,
+            shell,
+            previous_id,
+        } => record_command(
+            CommandEvent {
+                schema_version: SCHEMA_VERSION,
+                id,
+                command,
+                cwd,
+                started_at_ms,
+                duration_ms,
+                exit_code,
+                shell,
+                previous_event_id: previous_id,
+            },
+            config.events.retention,
+        ),
+        EventsAction::RecordSuggestion {
+            id,
+            command_event_id,
+            trigger,
+            candidate_source,
+            command,
+            outcome,
+            latency_ms,
+        } => {
+            let outcome = SuggestionOutcome::parse(&outcome).unwrap_or_else(|error| {
+                eprintln!("{error}");
+                std::process::exit(2);
+            });
+            record_suggestion(
+                SuggestionEvent {
+                    schema_version: SCHEMA_VERSION,
+                    id,
+                    command_event_id,
+                    trigger,
+                    candidate_source,
+                    command,
+                    outcome,
+                    latency_ms,
+                },
+                config.events.retention,
+            );
+        }
+    }
+}
+
+fn clear(confirmed: bool) {
+    if !confirmed {
+        eprintln!("Refusing to clear events without --yes");
+        std::process::exit(2);
+    }
+    if let Err(error) = events::clear() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+    println!("Cleared local command and suggestion events.");
+}
+
+fn inspect(retention: usize) {
+    let stats = events::inspect();
+    println!("Event store: {}", events::event_store_path().display());
+    println!("Schema version: {SCHEMA_VERSION}");
+    println!("Retention: last {retention} events");
+    println!("Command events: {}", stats.command_events);
+    println!("Suggestion events: {}", stats.suggestion_events);
+    println!("Shown: {}", stats.shown);
+    println!("Accepted: {}", stats.accepted);
+    println!("Executed: {}", stats.executed);
+    println!("Dismissed: {}", stats.dismissed);
+    println!("Malformed lines: {}", stats.malformed_lines);
+}
+
+fn record_command(event: CommandEvent, retention: usize) {
+    if let Err(error) = events::record_command(event, retention) {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn record_suggestion(event: SuggestionEvent, retention: usize) {
+    if let Err(error) = events::record_suggestion(event, retention) {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod events;
 pub mod init;
 pub mod learn;
 pub mod now;

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -3,9 +3,17 @@ use std::env;
 
 use crate::cache;
 use crate::config::AppConfig;
+use crate::events;
 use crate::learn::{self, db::LearnDb, pattern};
 use crate::predict::{self, main_cmd};
 use crate::shell::{self, HistoryItem, ShellKind};
+
+#[derive(Debug, Default)]
+pub struct InvocationContext<'a> {
+    pub after: Option<&'a str>,
+    pub exit_code: Option<i32>,
+    pub cwd: Option<&'a str>,
+}
 
 pub fn run(
     shell: &ShellKind,
@@ -13,8 +21,18 @@ pub fn run(
     config: &AppConfig,
     debug: bool,
     raw: bool,
-    after: Option<&str>,
+    context: InvocationContext<'_>,
 ) {
+    if raw {
+        if let (Some(command), Some(exit_code)) = (context.after, context.exit_code) {
+            if let Some(suggestion) = events::predict_after(command, exit_code, context.cwd, config)
+            {
+                print_raw_suggestion(Some(suggestion));
+                return;
+            }
+        }
+    }
+
     let history = shell::load_history(shell);
     if history.is_empty() {
         eprintln!(
@@ -25,7 +43,7 @@ pub fn run(
     }
 
     let cache_cmds = if raw {
-        recent_context(&history, ngram, after)
+        recent_context(&history, ngram, context.after)
     } else {
         cache::overwrite_soon_cache_from_history(shell, ngram);
         cache::read_soon_cache(ngram)
@@ -34,9 +52,7 @@ pub fn run(
         predict::predict_next_command(&history, ngram, &cache_cmds, config, debug && !raw);
 
     if raw {
-        if let Some(cmd) = suggestion.filter(|cmd| !cmd.chars().any(char::is_control)) {
-            println!("{cmd}");
-        }
+        print_raw_suggestion(suggestion);
         return;
     }
 
@@ -94,6 +110,12 @@ pub fn run(
                 println!("  {:>2}: {}", i + 1, cmd);
             }
         }
+    }
+}
+
+fn print_raw_suggestion(suggestion: Option<String>) {
+    if let Some(cmd) = suggestion.filter(|cmd| !cmd.chars().any(char::is_control)) {
+        println!("{cmd}");
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ pub struct AppConfig {
     pub update: UpdateConfig,
     #[serde(default)]
     pub llm: LlmConfig,
+    #[serde(default)]
+    pub events: EventsConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,6 +44,12 @@ pub struct LlmConfig {
     pub prompt: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventsConfig {
+    #[serde(default = "default_event_retention")]
+    pub retention: usize,
+}
+
 fn default_shell() -> String {
     "auto".to_string()
 }
@@ -52,6 +60,10 @@ fn default_ngram() -> usize {
 
 fn default_channel() -> String {
     "auto".to_string()
+}
+
+fn default_event_retention() -> usize {
+    10_000
 }
 
 fn default_ignored_commands() -> Vec<String> {
@@ -79,6 +91,14 @@ impl Default for UpdateConfig {
     fn default() -> Self {
         Self {
             channel: default_channel(),
+        }
+    }
+}
+
+impl Default for EventsConfig {
+    fn default() -> Self {
+        Self {
+            retention: default_event_retention(),
         }
     }
 }
@@ -133,6 +153,7 @@ impl AppConfig {
             }
             "llm.model" => Some(self.llm.model.clone()),
             "llm.prompt" => Some(self.llm.prompt.clone()),
+            "events.retention" => Some(self.events.retention.to_string()),
             _ => None,
         }
     }
@@ -168,6 +189,15 @@ impl AppConfig {
             "llm.api_key" => self.llm.api_key = value.to_string(),
             "llm.model" => self.llm.model = value.to_string(),
             "llm.prompt" => self.llm.prompt = value.to_string(),
+            "events.retention" => {
+                let retention = value
+                    .parse::<usize>()
+                    .map_err(|_| format!("Invalid event retention: {value}"))?;
+                if retention == 0 || retention > 1_000_000 {
+                    return Err("Event retention must be between 1 and 1000000".to_string());
+                }
+                self.events.retention = retention;
+            }
             _ => return Err(format!("Unknown config key: {}", key)),
         }
         Ok(())

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,284 @@
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use crate::config::AppConfig;
+use crate::predict::{is_ignored_command, main_cmd};
+
+pub const SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandEvent {
+    pub schema_version: u8,
+    pub id: String,
+    pub command: String,
+    pub cwd: String,
+    pub started_at_ms: i64,
+    pub duration_ms: u64,
+    pub exit_code: i32,
+    pub shell: String,
+    pub previous_event_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StoredEvent {
+    Command(CommandEvent),
+    Suggestion(SuggestionEvent),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuggestionEvent {
+    pub schema_version: u8,
+    pub id: String,
+    pub command_event_id: Option<String>,
+    pub trigger: String,
+    pub candidate_source: String,
+    pub command: String,
+    pub outcome: SuggestionOutcome,
+    pub latency_ms: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SuggestionOutcome {
+    Shown,
+    Accepted,
+    Executed,
+    Dismissed,
+}
+
+impl SuggestionOutcome {
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "shown" => Ok(Self::Shown),
+            "accepted" => Ok(Self::Accepted),
+            "executed" => Ok(Self::Executed),
+            "dismissed" => Ok(Self::Dismissed),
+            _ => Err(format!("Unknown suggestion outcome: {value}")),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct CandidateScore {
+    evidence: usize,
+    directory_matches: usize,
+    latest_index: usize,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct EventStats {
+    pub command_events: usize,
+    pub suggestion_events: usize,
+    pub shown: usize,
+    pub accepted: usize,
+    pub executed: usize,
+    pub dismissed: usize,
+    pub malformed_lines: usize,
+}
+
+pub fn event_store_path() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .expect("home directory")
+                .join(".local/share")
+        })
+        .join("soon")
+        .join("events.jsonl")
+}
+
+pub fn record_command(event: CommandEvent, retention: usize) -> Result<(), String> {
+    if event.command.trim().is_empty() || event.command.chars().any(char::is_control) {
+        return Err("Refusing to store an empty command or control characters".to_string());
+    }
+
+    append(&StoredEvent::Command(event), retention)
+}
+
+pub fn record_suggestion(event: SuggestionEvent, retention: usize) -> Result<(), String> {
+    if event.command.trim().is_empty() || event.command.chars().any(char::is_control) {
+        return Err("Refusing to store an empty suggestion or control characters".to_string());
+    }
+    if !matches!(event.trigger.as_str(), "manual" | "next-step" | "repair") {
+        return Err(format!("Unknown prediction trigger: {}", event.trigger));
+    }
+    if event.candidate_source.trim().is_empty()
+        || !event.latency_ms.is_finite()
+        || event.latency_ms.is_sign_negative()
+    {
+        return Err("Invalid suggestion source or latency".to_string());
+    }
+    append(&StoredEvent::Suggestion(event), retention)
+}
+
+pub fn inspect() -> EventStats {
+    let path = event_store_path();
+    let Ok(file) = File::open(path) else {
+        return EventStats::default();
+    };
+
+    let mut stats = EventStats::default();
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        match serde_json::from_str::<StoredEvent>(&line) {
+            Ok(StoredEvent::Command(_)) => stats.command_events += 1,
+            Ok(StoredEvent::Suggestion(event)) => {
+                stats.suggestion_events += 1;
+                match event.outcome {
+                    SuggestionOutcome::Shown => stats.shown += 1,
+                    SuggestionOutcome::Accepted => stats.accepted += 1,
+                    SuggestionOutcome::Executed => stats.executed += 1,
+                    SuggestionOutcome::Dismissed => stats.dismissed += 1,
+                }
+            }
+            Err(_) => stats.malformed_lines += 1,
+        }
+    }
+    stats
+}
+
+pub fn clear() -> Result<(), String> {
+    let path = event_store_path();
+    if !path.exists() {
+        return Ok(());
+    }
+    fs::remove_file(path).map_err(|error| format!("Failed to clear event store: {error}"))
+}
+
+pub fn predict_after(
+    command: &str,
+    exit_code: i32,
+    cwd: Option<&str>,
+    config: &AppConfig,
+) -> Option<String> {
+    let events = load_command_events();
+    let mut candidates = std::collections::HashMap::<String, CandidateScore>::new();
+    let successors: std::collections::HashMap<&str, &CommandEvent> = events
+        .iter()
+        .filter_map(|event| {
+            event
+                .previous_event_id
+                .as_deref()
+                .map(|previous_id| (previous_id, event))
+        })
+        .collect();
+    let wanted_success = exit_code == 0;
+
+    for (index, event) in events.iter().enumerate() {
+        if event.command.trim() != command.trim() || (event.exit_code == 0) != wanted_success {
+            continue;
+        }
+
+        let Some(next) = successors.get(event.id.as_str()) else {
+            continue;
+        };
+        if next.command.chars().any(char::is_control)
+            || is_ignored_command(main_cmd(&next.command), config)
+        {
+            continue;
+        }
+
+        let score = candidates.entry(next.command.clone()).or_default();
+        score.evidence += 1;
+        score.directory_matches += usize::from(cwd.is_some_and(|cwd| cwd == event.cwd));
+        score.latest_index = index;
+    }
+
+    let mut ranked: Vec<_> = candidates.into_iter().collect();
+    ranked.sort_by(|(command_a, score_a), (command_b, score_b)| {
+        score_b
+            .directory_matches
+            .cmp(&score_a.directory_matches)
+            .then_with(|| score_b.evidence.cmp(&score_a.evidence))
+            .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
+            .then_with(|| command_a.cmp(command_b))
+    });
+    ranked.into_iter().next().map(|(command, _)| command)
+}
+
+fn load_command_events() -> Vec<CommandEvent> {
+    let Ok(file) = File::open(event_store_path()) else {
+        return Vec::new();
+    };
+
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter_map(|line| serde_json::from_str::<StoredEvent>(&line).ok())
+        .filter_map(|event| match event {
+            StoredEvent::Command(command) => Some(command),
+            StoredEvent::Suggestion(_) => None,
+        })
+        .collect()
+}
+
+fn append(event: &StoredEvent, retention: usize) -> Result<(), String> {
+    if retention == 0 {
+        return Err("Event retention must be at least 1".to_string());
+    }
+    let path = event_store_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create event directory: {error}"))?;
+    }
+
+    let existing: Vec<StoredEvent> = File::open(&path)
+        .ok()
+        .map(BufReader::new)
+        .into_iter()
+        .flat_map(|reader| reader.lines().map_while(Result::ok))
+        .filter_map(|line| serde_json::from_str::<StoredEvent>(&line).ok())
+        .collect();
+    if existing.iter().any(|stored| same_identity(stored, event)) {
+        return Ok(());
+    }
+
+    if existing.len() >= retention {
+        let mut retained = existing;
+        retained.push(event.clone());
+        let keep_from = retained.len().saturating_sub(retention);
+        let mut encoded = Vec::new();
+        for retained_event in &retained[keep_from..] {
+            serde_json::to_writer(&mut encoded, retained_event)
+                .map_err(|error| format!("Failed to serialize retained event: {error}"))?;
+            encoded.push(b'\n');
+        }
+        let temp_path = path.with_extension(format!("jsonl.tmp-{}", std::process::id()));
+        fs::write(&temp_path, encoded)
+            .map_err(|error| format!("Failed to compact event store: {error}"))?;
+        fs::rename(&temp_path, &path)
+            .map_err(|error| format!("Failed to replace event store: {error}"))?;
+        return Ok(());
+    }
+
+    let needs_separator = fs::read(&path)
+        .ok()
+        .and_then(|contents| contents.last().copied())
+        .is_some_and(|last| last != b'\n');
+    let mut encoded =
+        serde_json::to_vec(event).map_err(|error| format!("Failed to serialize event: {error}"))?;
+    encoded.push(b'\n');
+    if needs_separator {
+        encoded.insert(0, b'\n');
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("Failed to open event store: {error}"))?;
+    file.write_all(&encoded)
+        .map_err(|error| format!("Failed to append event: {error}"))
+}
+
+fn same_identity(left: &StoredEvent, right: &StoredEvent) -> bool {
+    match (left, right) {
+        (StoredEvent::Command(left), StoredEvent::Command(right)) => left.id == right.id,
+        (StoredEvent::Suggestion(left), StoredEvent::Suggestion(right)) => {
+            left.id == right.id && left.outcome == right.outcome
+        }
+        _ => false,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cache;
 mod cli;
 mod commands;
 mod config;
+mod events;
 mod learn;
 mod predict;
 mod shell;
@@ -30,6 +31,7 @@ fn main() {
     match cli.command {
         Some(Commands::Init { shell }) => commands::init::run(shell),
         Some(Commands::Config { action }) => commands::config::run(action),
+        Some(Commands::Events { action }) => commands::events::run(action, &config),
         Some(Commands::Update) => commands::update::run(&config),
         Some(Commands::Learn { action }) => {
             // Learn works even with unknown shell (ingest-all detects automatically)
@@ -43,13 +45,36 @@ fn main() {
             require_known_shell(&shell);
             commands::stats::run(&shell, &config);
         }
-        Some(Commands::Now { raw, after }) => {
+        Some(Commands::Now {
+            raw,
+            after,
+            exit_code,
+            cwd,
+        }) => {
             require_known_shell(&shell);
-            commands::now::run(&shell, ngram, &config, cli.debug, raw, after.as_deref());
+            commands::now::run(
+                &shell,
+                ngram,
+                &config,
+                cli.debug,
+                raw,
+                commands::now::InvocationContext {
+                    after: after.as_deref(),
+                    exit_code,
+                    cwd: cwd.as_deref(),
+                },
+            );
         }
         None => {
             require_known_shell(&shell);
-            commands::now::run(&shell, ngram, &config, cli.debug, false, None);
+            commands::now::run(
+                &shell,
+                ngram,
+                &config,
+                cli.debug,
+                false,
+                commands::now::InvocationContext::default(),
+            );
         }
     }
 }

--- a/src/shell/soon.zsh
+++ b/src/shell/soon.zsh
@@ -12,6 +12,22 @@ if [[ -o interactive ]]; then
   typeset -g _soon_highlight=''
   typeset -gi _soon_fd=-1
   typeset -g SOON_LAST_LATENCY_MS=''
+  typeset -g _soon_running_command=''
+  typeset -g _soon_running_cwd=''
+  typeset -gF _soon_running_started=0
+  typeset -g _soon_running_event_id=''
+  typeset -g _soon_previous_event_id=''
+  typeset -g _soon_prediction_trigger='manual'
+  typeset -g _soon_prediction_event_id=''
+  typeset -g _soon_suggestion_id=''
+  typeset -g _soon_suggestion_trigger=''
+  typeset -g _soon_suggestion_event_id=''
+  typeset -g _soon_suggestion_latency=''
+  typeset -g _soon_accepted_command=''
+  typeset -g _soon_accepted_id=''
+  typeset -g _soon_accepted_trigger=''
+  typeset -g _soon_accepted_event_id=''
+  typeset -g _soon_accepted_latency=''
   typeset -g _soon_previous_ctrl_f=${${(z)$(bindkey '^F' 2>/dev/null)}[-1]}
   [[ -n $_soon_previous_ctrl_f ]] || _soon_previous_ctrl_f='.forward-char'
 
@@ -61,8 +77,14 @@ if [[ -o interactive ]]; then
     if IFS= read -r line <&$fd && [[ $line == *$'\t'* ]]; then
       SOON_LAST_LATENCY_MS=${line%%$'\t'*}
       _soon_suggestion=${line#*$'\t'}
+      _soon_suggestion_id="${EPOCHREALTIME//./}-$$-$RANDOM"
+      _soon_suggestion_trigger=$_soon_prediction_trigger
+      _soon_suggestion_event_id=$_soon_prediction_event_id
+      _soon_suggestion_latency=$SOON_LAST_LATENCY_MS
+      _soon_record_suggestion shown
     else
       _soon_suggestion=''
+      _soon_suggestion_id=''
     fi
     zle -F $fd 2>/dev/null || true
     (( fd == _soon_fd )) && _soon_fd=-1
@@ -70,20 +92,74 @@ if [[ -o interactive ]]; then
     zle _soon_apply_suggestion
   }
 
+  function _soon_record_suggestion() {
+    local outcome=$1
+    [[ -n $_soon_suggestion_id && -n $_soon_suggestion ]] || return 0
+
+    _soon_emit_suggestion "$outcome" "$_soon_suggestion_id" "$_soon_suggestion_trigger" "$_soon_suggestion_event_id" "$_soon_suggestion_latency" "$_soon_suggestion"
+  }
+
+  function _soon_emit_suggestion() {
+    local outcome=$1
+    local suggestion_id=$2
+    local trigger=$3
+    local command_event_id=$4
+    local latency=$5
+    local command_text=$6
+
+    local -a event_args=(
+      events record-suggestion
+      --id "$suggestion_id"
+      --trigger "$trigger"
+      --candidate-source history
+      --command "$command_text"
+      --outcome "$outcome"
+      --latency-ms "$latency"
+    )
+    [[ -n $command_event_id ]] && event_args+=(--command-event-id "$command_event_id")
+    command soon "${event_args[@]}" >/dev/null 2>&1 &!
+  }
+
   function _soon_start_prediction() {
     local after=${1:-}
+    local exit_status=${2:-}
+    local command_cwd=${3:-}
+    local event_id=${4:-}
+    local previous_event_id=${5:-}
+    local started_at_ms=${6:-}
+    local duration_ms=${7:-}
     local started=$EPOCHREALTIME
     _soon_cancel_prediction
     _soon_suggestion=''
 
     if [[ -n $after ]]; then
+      if (( exit_status == 0 )); then
+        _soon_prediction_trigger='next-step'
+      else
+        _soon_prediction_trigger='repair'
+      fi
+      _soon_prediction_event_id=$event_id
       exec {_soon_fd}< <(
         local suggestion elapsed
-        suggestion=$(command soon --shell zsh --ngram 1 now --raw --after "$after" 2>/dev/null)
+        local -a record_args=(
+          events record-command
+          --id "$event_id"
+          --command "$after"
+          --cwd "$command_cwd"
+          --started-at-ms "$started_at_ms"
+          --duration-ms "$duration_ms"
+          --exit-code "$exit_status"
+          --shell zsh
+        )
+        [[ -n $previous_event_id ]] && record_args+=(--previous-id "$previous_event_id")
+        command soon "${record_args[@]}" >/dev/null 2>&1
+        suggestion=$(command soon --shell zsh --ngram 1 now --raw --after "$after" --exit-code "$exit_status" --cwd "$command_cwd" 2>/dev/null)
         elapsed=$(( (EPOCHREALTIME - started) * 1000.0 ))
         printf '%.3f\t%s\n' $elapsed "$suggestion"
       )
     else
+      _soon_prediction_trigger='manual'
+      _soon_prediction_event_id=''
       exec {_soon_fd}< <(
         local suggestion elapsed
         suggestion=$(command soon --shell zsh now --raw 2>/dev/null)
@@ -107,12 +183,68 @@ if [[ -o interactive ]]; then
   }
 
   function _soon_preexec() {
-    _soon_start_prediction "$1"
+    if [[ -n $_soon_suggestion_id && -n $_soon_suggestion ]]; then
+      _soon_record_suggestion dismissed
+    fi
+    if [[ -n $_soon_accepted_command && $1 == $_soon_accepted_command ]]; then
+      _soon_emit_suggestion executed "$_soon_accepted_id" "$_soon_accepted_trigger" "$_soon_accepted_event_id" "$_soon_accepted_latency" "$_soon_accepted_command"
+    fi
+    _soon_accepted_command=''
+    _soon_accepted_id=''
+    _soon_accepted_trigger=''
+    _soon_accepted_event_id=''
+    _soon_accepted_latency=''
+    _soon_cancel_prediction
+    _soon_suggestion=''
+    _soon_suggestion_id=''
+    _soon_suggestion_trigger=''
+    _soon_suggestion_event_id=''
+    _soon_suggestion_latency=''
+    _soon_refresh_display
+    local -a command_words=(${(z)1})
+    if [[ ${command_words[1]:-} == soon ]] ||
+       [[ ${command_words[1]:-} == command && ${command_words[2]:-} == soon ]]; then
+      _soon_running_command=''
+      return 0
+    fi
+    _soon_running_command=$1
+    _soon_running_cwd=$PWD
+    _soon_running_started=$EPOCHREALTIME
+    _soon_running_event_id="${EPOCHREALTIME//./}-$$-$RANDOM"
     return 0
+  }
+
+  function _soon_precmd() {
+    local exit_status=$?
+
+    if [[ -n $_soon_running_command ]]; then
+      local command=$_soon_running_command
+      local command_cwd=$_soon_running_cwd
+      local event_id=$_soon_running_event_id
+      local previous_event_id=$_soon_previous_event_id
+      local -i started_at_ms=$(( _soon_running_started * 1000.0 ))
+      local -i duration_ms=$(( (EPOCHREALTIME - _soon_running_started) * 1000.0 ))
+
+      _soon_running_command=''
+      _soon_running_cwd=''
+      _soon_running_started=0
+      _soon_running_event_id=''
+      _soon_previous_event_id=$event_id
+
+      _soon_start_prediction "$command" "$exit_status" "$command_cwd" "$event_id" "$previous_event_id" "$started_at_ms" "$duration_ms"
+    fi
+
+    return $exit_status
   }
 
   function _soon_accept() {
     if [[ -z $BUFFER && -n $_soon_suggestion ]]; then
+      _soon_record_suggestion accepted
+      _soon_accepted_command=$_soon_suggestion
+      _soon_accepted_id=$_soon_suggestion_id
+      _soon_accepted_trigger=$_soon_suggestion_trigger
+      _soon_accepted_event_id=$_soon_suggestion_event_id
+      _soon_accepted_latency=$_soon_suggestion_latency
       BUFFER=$_soon_suggestion
       CURSOR=${#BUFFER}
       _soon_suggestion=''
@@ -127,6 +259,7 @@ if [[ -o interactive ]]; then
     add-zle-hook-widget -d line-init _soon_line_init 2>/dev/null || true
     add-zle-hook-widget -d line-pre-redraw _soon_line_pre_redraw 2>/dev/null || true
     add-zsh-hook -d preexec _soon_preexec 2>/dev/null || true
+    add-zsh-hook -d precmd _soon_precmd 2>/dev/null || true
     bindkey '^F' "$_soon_previous_ctrl_f"
     zle -D _soon_accept 2>/dev/null || true
     zle -D _soon_apply_suggestion 2>/dev/null || true
@@ -143,5 +276,6 @@ if [[ -o interactive ]]; then
   add-zle-hook-widget line-init _soon_line_init
   add-zle-hook-widget line-pre-redraw _soon_line_pre_redraw
   add-zsh-hook preexec _soon_preexec
+  add-zsh-hook precmd _soon_precmd
   bindkey '^F' _soon_accept
 fi

--- a/tests/events_cli.rs
+++ b/tests/events_cli.rs
@@ -1,0 +1,343 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn isolated_home() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let path =
+        std::env::temp_dir().join(format!("soon-events-test-{}-{nonce}", std::process::id()));
+    std::fs::create_dir_all(&path).expect("create isolated home");
+    path
+}
+
+fn soon(home: &PathBuf) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_soon"));
+    command
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"));
+    command
+}
+
+fn record_command(
+    home: &PathBuf,
+    id: &str,
+    command: &str,
+    exit_code: &str,
+    previous_id: Option<&str>,
+) {
+    let mut args = vec![
+        "events",
+        "record-command",
+        "--id",
+        id,
+        "--command",
+        command,
+        "--cwd",
+        "/tmp/soon-project",
+        "--started-at-ms",
+        "1000",
+        "--duration-ms",
+        "25",
+        "--exit-code",
+        exit_code,
+        "--shell",
+        "zsh",
+    ];
+    if let Some(previous_id) = previous_id {
+        args.extend(["--previous-id", previous_id]);
+    }
+
+    let output = soon(home)
+        .args(args)
+        .output()
+        .expect("record command event");
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn recorded_command_is_counted_without_leaking_its_text() {
+    let home = isolated_home();
+    let secret_marker = "cargo test --workspace --token should-not-be-printed";
+
+    let record = soon(&home)
+        .args([
+            "events",
+            "record-command",
+            "--id",
+            "command-1",
+            "--command",
+            secret_marker,
+            "--cwd",
+            "/tmp/soon-project",
+            "--started-at-ms",
+            "1000",
+            "--duration-ms",
+            "25",
+            "--exit-code",
+            "0",
+            "--shell",
+            "zsh",
+        ])
+        .output()
+        .expect("record command event");
+
+    assert!(
+        record.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&record.stderr)
+    );
+    assert!(record.stdout.is_empty(), "record command wrote to stdout");
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect event store");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        inspect.status.success(),
+        "inspect failed: {}",
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    assert!(stdout.contains("Schema version: 1"), "{stdout}");
+    assert!(stdout.contains("Command events: 1"), "{stdout}");
+    assert!(stdout.contains("Suggestion events: 0"), "{stdout}");
+    assert!(
+        !stdout.contains(secret_marker),
+        "inspect leaked command text"
+    );
+}
+
+#[test]
+fn command_result_selects_repair_or_next_step_policy() {
+    let home = isolated_home();
+    std::fs::write(
+        home.join(".zsh_history"),
+        "cargo test\necho history-fallback\ncargo test\necho history-fallback\n",
+    )
+    .expect("write Zsh history");
+
+    record_command(&home, "failed-1", "cargo test", "1", None);
+    record_command(
+        &home,
+        "repair-1",
+        "cargo test -- --nocapture",
+        "0",
+        Some("failed-1"),
+    );
+    record_command(&home, "success-1", "cargo test", "0", Some("repair-1"));
+    record_command(
+        &home,
+        "next-1",
+        "git push --force-with-lease",
+        "0",
+        Some("success-1"),
+    );
+
+    let repair = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "1",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict repair command");
+    let next_step = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict next-step command");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(repair.status.success(), "repair prediction failed");
+    assert!(next_step.status.success(), "next-step prediction failed");
+    assert_eq!(
+        String::from_utf8(repair.stdout).expect("UTF-8 repair"),
+        "cargo test -- --nocapture\n"
+    );
+    assert_eq!(
+        String::from_utf8(next_step.stdout).expect("UTF-8 next step"),
+        "git push --force-with-lease\n"
+    );
+}
+
+#[test]
+fn clearing_events_requires_confirmation_and_empties_the_store() {
+    let home = isolated_home();
+    record_command(&home, "command-1", "cargo test", "0", None);
+
+    let refused = soon(&home)
+        .args(["events", "clear"])
+        .output()
+        .expect("refuse unconfirmed clear");
+    assert!(!refused.status.success(), "unconfirmed clear succeeded");
+
+    let cleared = soon(&home)
+        .args(["events", "clear", "--yes"])
+        .output()
+        .expect("clear event store");
+    assert!(
+        cleared.status.success(),
+        "confirmed clear failed: {}",
+        String::from_utf8_lossy(&cleared.stderr)
+    );
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect cleared event store");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Command events: 0"), "{stdout}");
+    assert!(stdout.contains("Suggestion events: 0"), "{stdout}");
+}
+
+#[test]
+fn suggestion_feedback_outcomes_are_counted_without_leaking_candidates() {
+    let home = isolated_home();
+    let candidate = "deploy --token should-not-be-printed";
+
+    for outcome in ["shown", "accepted", "executed", "dismissed"] {
+        let output = soon(&home)
+            .args([
+                "events",
+                "record-suggestion",
+                "--id",
+                "suggestion-1",
+                "--command-event-id",
+                "command-1",
+                "--trigger",
+                "repair",
+                "--candidate-source",
+                "history",
+                "--command",
+                candidate,
+                "--outcome",
+                outcome,
+                "--latency-ms",
+                "12.5",
+            ])
+            .output()
+            .expect("record suggestion event");
+        assert!(
+            output.status.success(),
+            "record {outcome} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect suggestion events");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Suggestion events: 4"), "{stdout}");
+    assert!(stdout.contains("Shown: 1"), "{stdout}");
+    assert!(stdout.contains("Accepted: 1"), "{stdout}");
+    assert!(stdout.contains("Executed: 1"), "{stdout}");
+    assert!(stdout.contains("Dismissed: 1"), "{stdout}");
+    assert!(!stdout.contains(candidate), "inspect leaked candidate text");
+}
+
+#[test]
+fn duplicate_command_event_ids_are_idempotent() {
+    let home = isolated_home();
+    record_command(&home, "same-command", "cargo test", "0", None);
+    record_command(&home, "same-command", "cargo test", "0", None);
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect deduplicated events");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Command events: 1"), "{stdout}");
+}
+
+#[test]
+fn configured_retention_keeps_only_the_newest_events() {
+    let home = isolated_home();
+    let configure = soon(&home)
+        .args(["config", "set", "events.retention", "3"])
+        .output()
+        .expect("configure event retention");
+    assert!(
+        configure.status.success(),
+        "configure failed: {}",
+        String::from_utf8_lossy(&configure.stderr)
+    );
+
+    record_command(&home, "command-1", "echo one", "0", None);
+    record_command(&home, "command-2", "echo two", "0", Some("command-1"));
+    record_command(&home, "command-3", "echo three", "0", Some("command-2"));
+    record_command(&home, "command-4", "echo four", "0", Some("command-3"));
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect retained events");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Retention: last 3 events"), "{stdout}");
+    assert!(stdout.contains("Command events: 3"), "{stdout}");
+}
+
+#[test]
+fn a_truncated_final_line_does_not_corrupt_the_next_event() {
+    let home = isolated_home();
+    let initial = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect event path");
+    let initial_stdout = String::from_utf8(initial.stdout).expect("UTF-8 inspect output");
+    let event_path = initial_stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Event store: "))
+        .map(PathBuf::from)
+        .expect("event store path");
+    std::fs::create_dir_all(event_path.parent().expect("event parent"))
+        .expect("create event directory");
+    std::fs::write(&event_path, b"{\"truncated\":").expect("write truncated final event line");
+
+    record_command(&home, "command-1", "cargo test", "0", None);
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect recovered event store");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Command events: 1"), "{stdout}");
+    assert!(stdout.contains("Malformed lines: 1"), "{stdout}");
+}

--- a/tests/zsh_integration.zsh
+++ b/tests/zsh_integration.zsh
@@ -15,11 +15,13 @@ local test_root=${TMPDIR:-/tmp}/soon-zsh-harness-$$
 local fake_bin=$test_root/bin
 local integration_file=$test_root/integration.zsh
 local accepted_file=/tmp/soon-zsh-accept-$$
+local repair_file=/tmp/soon-zsh-repair-$$
+local calls_file=$test_root/soon-calls.log
 mkdir -p $fake_bin
 
 function cleanup() {
   zpty -d soon_shell 2>/dev/null || true
-  rm -f $accepted_file
+  rm -f $accepted_file $repair_file
   rm -rf $test_root
 }
 trap cleanup EXIT INT TERM HUP
@@ -28,8 +30,16 @@ $soon_bin init zsh > $integration_file
 
 cat > $fake_bin/soon <<FAKE_SOON
 #!/bin/sh
+printf '%s\n' "\$*" >> '$calls_file'
+case " \$* " in
+  *' events record-command '*|*' events record-suggestion '*) exit 0 ;;
+esac
 sleep 0.05
-printf '%s\n' 'touch $accepted_file'
+case " \$* " in
+  *' --exit-code 0 '*) printf '%s\n' 'touch $accepted_file' ;;
+  *' --exit-code '*) printf '%s\n' 'touch $repair_file' ;;
+  *) printf '%s\n' 'touch $accepted_file' ;;
+esac
 FAKE_SOON
 chmod +x $fake_bin/soon
 
@@ -97,15 +107,34 @@ function wait_for_file() {
   return 1
 }
 
+function wait_for_log() {
+  local needle=$1
+  local -F deadline=$(( EPOCHREALTIME + 5 ))
+
+  while (( EPOCHREALTIME < deadline )); do
+    if [[ -f $calls_file ]] && [[ "$(<$calls_file)" == *$needle* ]]; then
+      return 0
+    fi
+    sleep 0.02
+  done
+
+  print -u2 -- "timed out waiting for log entry: $needle"
+  [[ -f $calls_file ]] && print -u2 -- "soon calls: ${(qqq)$(<$calls_file)}"
+  return 1
+}
+
 # Render and accept a suggestion at an empty prompt.
 wait_for_output 'SOON_PROMPT> '
 transcript=''
 wait_for_output "touch $accepted_file"
+wait_for_log '--outcome shown'
 transcript=''
 zpty -w -n soon_shell $'\x06'
+wait_for_log '--outcome accepted'
 sleep 0.05
 zpty -w -n soon_shell $'\n'
 wait_for_file $accepted_file
+wait_for_log '--outcome executed'
 wait_for_output 'SOON_PROMPT> '
 
 # Normal typing ignores the ghost suggestion instead of modifying the buffer.
@@ -116,8 +145,39 @@ transcript=''
 zpty -w soon_shell '[[ $SOON_LAST_LATENCY_MS == <->.<-> ]] && print -r -- SOON_TYPED_NORMALLY'
 wait_for_output 'SOON_TYPED_NORMALLY'
 wait_for_output 'SOON_PROMPT> '
+wait_for_log '--outcome dismissed'
 [[ ! -e $accepted_file ]] || {
   print -u2 -- 'typing a command unexpectedly accepted the suggestion'
+  return 1
+}
+
+# Completed commands drive distinct Next-step and Repair predictions, while preserving `$?`.
+transcript=''
+zpty -w soon_shell 'true'
+wait_for_output 'SOON_PROMPT> '
+wait_for_log 'record-command --id'
+wait_for_log '--command true'
+wait_for_log '--exit-code 0'
+
+transcript=''
+zpty -w soon_shell 'false'
+wait_for_output 'SOON_PROMPT> '
+wait_for_output "touch $repair_file"
+wait_for_log '--command false'
+wait_for_log '--exit-code 1'
+
+transcript=''
+zpty -w soon_shell 'print -r -- "SOON_STATUS:$?"'
+wait_for_output 'SOON_STATUS:1'
+wait_for_output 'SOON_PROMPT> '
+
+# Invoking soon is a manual prediction trigger, not a command event to learn.
+transcript=''
+zpty -w soon_shell 'soon'
+wait_for_output 'SOON_PROMPT> '
+sleep 0.1
+[[ "$(<$calls_file)" != *'--command soon --cwd'* ]] || {
+  print -u2 -- 'manual soon invocation was recorded as a command event'
   return 1
 }
 


### PR DESCRIPTION
## Summary

- move Zsh prediction from `preexec` to a completed-command lifecycle: `preexec` records start context and `precmd` captures exit status and duration before launching asynchronous prediction
- select distinct Next-step and Repair evidence from prior successful or failed command transitions, with the existing history predictor as fallback
- persist versioned command and suggestion events in a retained local JSONL log with idempotent IDs and truncated-line recovery
- record shown, accepted, executed, and dismissed suggestion outcomes without printing command text from inspection
- add `soon events inspect`, confirmed `soon events clear --yes`, and configurable `events.retention`
- keep manual `soon` invocations out of learned command events and preserve the user's observed `$?`

## Why

The previous hook predicted in `preexec`, before the command had run, so it could not distinguish a successful workflow step from a failed command that needed repair. It also had no durable feedback loop. This change establishes the v0.4 local-agent event boundary without requiring a model or network service.

## Safety and behavior

- suggestions remain editable text and are never executed automatically
- command and suggestion recording is local and non-blocking
- `inspect` reports only path, schema, retention, aggregate outcomes, and malformed-line count
- clearing requires `--yes`
- broad sensitive-command filtering remains scoped to #9

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (13 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `uvx pre-commit run --all-files`
- `git diff --check`

Closes #8
Refs #4
Refs #9
Refs #11

## Summary by Sourcery

通过已完成命令的生命周期事件驱动 Zsh 命令建议，并添加本地事件存储及 CLI 工具，用于检查、清理以及将其用于下一步/修复预测。

新特性：
- 跟踪已完成的 Zsh 命令及其耗时、cwd 和退出状态，以驱动异步的下一步和修复建议。
- 引入基于 JSONL 的本地命令与建议事件存储，支持可配置的保留策略和幂等的事件 ID。
- 添加 `soon events` CLI 子命令，用于检查事件统计信息、在确认后清空存储，以及从 shell 集成记录命令/建议事件。
- 扩展 `soon now`，使其接受命令退出码和 cwd，用于在回退到基于历史的建议之前进行上下文感知的预测。

改进：
- 优化 Zsh 集成，以区分手动预测和来自已学习命令事件的预测，并避免更改用户可见的退出状态。
- 在事件检查输出中避免泄露命令或建议文本，同时仍然报告计数和模式（schema）信息。

文档：
- 更新 README，补充事件存储、保留配置以及新的 `soon events` 子命令的文档。

测试：
- 添加 Zsh 生命周期的集成测试，以验证建议结果，并确保手动调用 `soon` 不会被学习为命令事件。
- 添加 CLI 测试，覆盖事件记录、检查、清理、保留行为、幂等 ID，以及从被截断的事件日志行中恢复的能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Drive Zsh command suggestions from completed-command lifecycle events and add a local event store with CLI tools to inspect, clear, and use it for next-step/repair predictions.

New Features:
- Track completed Zsh commands with timing, cwd, and exit status to drive asynchronous next-step and repair suggestions.
- Introduce a local JSONL-backed command and suggestion event store with configurable retention and idempotent event IDs.
- Add `soon events` CLI subcommands to inspect event stats, clear the store with confirmation, and record command/suggestion events from shell integrations.
- Extend `soon now` to accept command exit code and cwd for context-aware prediction before falling back to history-based suggestions.

Enhancements:
- Refine Zsh integration to distinguish manual prediction from learned command events and avoid altering the user-visible exit status.
- Avoid leaking command or suggestion text in event inspection output while still reporting counts and schema information.

Documentation:
- Update README with documentation for the events store, retention configuration, and the new `soon events` subcommand.

Tests:
- Add integration tests for the Zsh lifecycle to validate suggestion outcomes and ensure manual `soon` invocations are not learned as command events.
- Add CLI tests covering event recording, inspection, clearing, retention behavior, idempotent IDs, and recovery from truncated event log lines.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过已完成命令的生命周期事件驱动 Zsh 命令建议，并添加本地事件存储及 CLI 工具，用于检查、清理以及将其用于下一步/修复预测。

新特性：
- 跟踪已完成的 Zsh 命令及其耗时、cwd 和退出状态，以驱动异步的下一步和修复建议。
- 引入基于 JSONL 的本地命令与建议事件存储，支持可配置的保留策略和幂等的事件 ID。
- 添加 `soon events` CLI 子命令，用于检查事件统计信息、在确认后清空存储，以及从 shell 集成记录命令/建议事件。
- 扩展 `soon now`，使其接受命令退出码和 cwd，用于在回退到基于历史的建议之前进行上下文感知的预测。

改进：
- 优化 Zsh 集成，以区分手动预测和来自已学习命令事件的预测，并避免更改用户可见的退出状态。
- 在事件检查输出中避免泄露命令或建议文本，同时仍然报告计数和模式（schema）信息。

文档：
- 更新 README，补充事件存储、保留配置以及新的 `soon events` 子命令的文档。

测试：
- 添加 Zsh 生命周期的集成测试，以验证建议结果，并确保手动调用 `soon` 不会被学习为命令事件。
- 添加 CLI 测试，覆盖事件记录、检查、清理、保留行为、幂等 ID，以及从被截断的事件日志行中恢复的能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Drive Zsh command suggestions from completed-command lifecycle events and add a local event store with CLI tools to inspect, clear, and use it for next-step/repair predictions.

New Features:
- Track completed Zsh commands with timing, cwd, and exit status to drive asynchronous next-step and repair suggestions.
- Introduce a local JSONL-backed command and suggestion event store with configurable retention and idempotent event IDs.
- Add `soon events` CLI subcommands to inspect event stats, clear the store with confirmation, and record command/suggestion events from shell integrations.
- Extend `soon now` to accept command exit code and cwd for context-aware prediction before falling back to history-based suggestions.

Enhancements:
- Refine Zsh integration to distinguish manual prediction from learned command events and avoid altering the user-visible exit status.
- Avoid leaking command or suggestion text in event inspection output while still reporting counts and schema information.

Documentation:
- Update README with documentation for the events store, retention configuration, and the new `soon events` subcommand.

Tests:
- Add integration tests for the Zsh lifecycle to validate suggestion outcomes and ensure manual `soon` invocations are not learned as command events.
- Add CLI tests covering event recording, inspection, clearing, retention behavior, idempotent IDs, and recovery from truncated event log lines.

</details>

</details>