### PR TITLE
feat: filter sensitive command data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +454,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +610,7 @@ dependencies = [
  "colored",
  "counter",
  "dirs",
+ "regex",
  "serde",
  "serde_json",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ toml = "0.8"
 serde_json = "1"
 ureq = "3"
 chrono = { version = "0.4", features = ["serde"] }
+regex = "1"

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and t
 | Current source | v0.4 target |
 |---|---|
 | On-demand command plus opt-in Zsh loop | Coherent beta install and clean-session smoke test |
-| Background ghost suggestion with `Ctrl-F` acceptance | Manual, successful-command Next-step, and failed-command Repair triggers |
-| Deterministic frequency and recency ranking | Safe command and suggestion events with feedback |
-| Local config plus experimental learning tools | Sensitive-command controls and local replay metrics |
+| Manual, successful-command Next-step, and failed-command Repair triggers | Useful cold starts from a safe history import |
+| Retained command and suggestion events with feedback | Local replay quality and latency metrics |
+| Built-in and user-configured sensitive-command filters | A documented v0.4 privacy and release audit |
 
 The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). Work is tracked in the public [Personal Terminal Agent Project](https://github.com/users/HsiangNianian/projects/7).
 
@@ -137,9 +137,30 @@ The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milest
 
 `soon`, `soon now`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
 
-The current integration honors configured ignored executables and refuses multiline/control-character output, but the broader sensitive-command filter tracked in [#9](https://github.com/HsiangNianian/soon/issues/9) is not shipped yet. Treat this source build as a prototype for histories that may contain inline credentials.
+The current source rejects likely inline API keys, tokens, authorization headers, password flags, private-key material, and known credential prefixes before storing a command or suggestion. It applies the same filter again before ranking or rendering shell history, old event data, legacy learn data, provider context, and model output. Rejections report a category, not the command text.
 
-`soon learn ask` is different: it is an optional experimental path that sends recent command context, the current directory, and time context to the OpenAI-compatible or Ollama endpoint you configure. API credentials are currently stored in the local config file. Do not enable remote enrichment for sensitive histories; safer capture, filtering, and credential guidance are tracked in [#9](https://github.com/HsiangNianian/soon/issues/9).
+Add exact case-sensitive exclusions or regular-expression exclusions without editing stored data:
+
+```bash
+soon config set privacy.excluded_literals 'company-deploy --production'
+soon config set privacy.excluded_patterns '(?i)^kubectl .*--context production'
+```
+
+Comma-separated values configure more than one exclusion. Literal values are redacted from `soon config`, `config get`, and successful `config set` output. Invalid regular expressions are rejected before the configuration is saved.
+
+`soon learn ask` is different: it is an optional experimental path that sends only filtered recent commands and the current directory to the OpenAI-compatible or Ollama endpoint you configure. It does not send event IDs, exit codes, feedback, stdout, or stderr. Model candidates pass through the same local filter before display.
+
+Provider credentials are read at request time from an environment variable and are never stored or printed by soon. The default variable is `SOON_LLM_API_KEY`; configure a different variable name with `llm.api_key_env`. For example, this Zsh flow keeps the value out of shell history:
+
+```zsh
+soon config set llm.provider openai
+soon config set llm.api_url https://api.openai.com
+read -rs 'SOON_LLM_API_KEY?API key: '
+print
+export SOON_LLM_API_KEY
+```
+
+Ollama can run without a credential. The legacy `llm.api_key` setting is rejected.
 
 The Zsh lifecycle integration stores local command and suggestion events in a retained JSONL log under the operating system's application-data directory. Inspect its exact path, schema version, retention, and aggregate counts without printing command text:
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -15,7 +15,7 @@ pub fn run(action: Option<ConfigAction>) {
 
 fn show_all() {
     let config = AppConfig::load();
-    let content = toml::to_string_pretty(&config)
+    let content = toml::to_string_pretty(&config.redacted())
         .unwrap_or_else(|_| "Failed to serialize config".to_string());
     let path = AppConfig::config_path();
 
@@ -75,7 +75,8 @@ fn get_value(key: &str) {
             eprintln!("  general.shell, general.ngram, general.ignored_commands");
             eprintln!("  update.channel");
             eprintln!("  events.retention");
-            eprintln!("  llm.provider, llm.api_url, llm.api_key, llm.model, llm.prompt");
+            eprintln!("  privacy.excluded_literals, privacy.excluded_patterns");
+            eprintln!("  llm.provider, llm.api_url, llm.api_key_env, llm.model, llm.prompt");
             std::process::exit(1);
         }
     }
@@ -86,7 +87,11 @@ fn set_value(key: &str, value: &str) {
     match config.set_value(key, value) {
         Ok(()) => match config.save() {
             Ok(()) => {
-                println!("{}", format!("{} = {}", key, value).green());
+                if key == "privacy.excluded_literals" {
+                    println!("{}", format!("{} = <redacted>", key).green());
+                } else {
+                    println!("{}", format!("{} = {}", key, value).green());
+                }
             }
             Err(e) => {
                 eprintln!("{}", format!("Failed to save config: {}", e).red());

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -27,7 +27,7 @@ pub fn run(action: EventsAction, config: &AppConfig) {
                 shell,
                 previous_event_id: previous_id,
             },
-            config.events.retention,
+            config,
         ),
         EventsAction::RecordSuggestion {
             id,
@@ -53,7 +53,7 @@ pub fn run(action: EventsAction, config: &AppConfig) {
                     outcome,
                     latency_ms,
                 },
-                config.events.retention,
+                config,
             );
         }
     }
@@ -85,15 +85,15 @@ fn inspect(retention: usize) {
     println!("Malformed lines: {}", stats.malformed_lines);
 }
 
-fn record_command(event: CommandEvent, retention: usize) {
-    if let Err(error) = events::record_command(event, retention) {
+fn record_command(event: CommandEvent, config: &AppConfig) {
+    if let Err(error) = events::record_command(event, config) {
         eprintln!("{error}");
         std::process::exit(1);
     }
 }
 
-fn record_suggestion(event: SuggestionEvent, retention: usize) {
-    if let Err(error) = events::record_suggestion(event, retention) {
+fn record_suggestion(event: SuggestionEvent, config: &AppConfig) {
+    if let Err(error) = events::record_suggestion(event, config) {
         eprintln!("{error}");
         std::process::exit(1);
     }

--- a/src/commands/learn.rs
+++ b/src/commands/learn.rs
@@ -5,16 +5,17 @@ use crate::cli::LearnAction;
 use crate::config::AppConfig;
 use crate::learn::{self, db::LearnDb, llm, markov, pattern, trigram};
 use crate::predict::main_cmd;
+use crate::privacy;
 use crate::shell::{self, ShellKind};
 
 pub fn run(action: Option<LearnAction>, shell: &ShellKind, config: &AppConfig) {
     match action {
         None => show_status(config),
-        Some(LearnAction::Ingest) => ingest_current(shell),
-        Some(LearnAction::IngestAll) => ingest_all(),
-        Some(LearnAction::Stats) => show_stats(),
+        Some(LearnAction::Ingest) => ingest_current(shell, config),
+        Some(LearnAction::IngestAll) => ingest_all(config),
+        Some(LearnAction::Stats) => show_stats(config),
         Some(LearnAction::Predict { num }) => predict(shell, config, num),
-        Some(LearnAction::Similar { query, num }) => similar(&query, num),
+        Some(LearnAction::Similar { query, num }) => similar(&query, num, config),
         Some(LearnAction::Ask { num }) => ask_llm(shell, config, num),
         Some(LearnAction::Reset) => reset(),
     }
@@ -75,13 +76,13 @@ fn show_status(config: &AppConfig) {
     }
 }
 
-fn ingest_current(shell: &ShellKind) {
+fn ingest_current(shell: &ShellKind, config: &AppConfig) {
     let db_path = learn::db_path();
     let mut db = LearnDb::load(&db_path);
 
     println!("{}", format!("Ingesting history from {}...", shell).cyan());
 
-    let count = pattern::ingest_shell_history(&mut db, shell);
+    let count = pattern::ingest_shell_history(&mut db, shell, config);
 
     // Rebuild trigram index
     println!("{}", "Rebuilding trigram index...".dimmed());
@@ -104,7 +105,7 @@ fn ingest_current(shell: &ShellKind) {
     }
 }
 
-fn ingest_all() {
+fn ingest_all(config: &AppConfig) {
     let db_path = learn::db_path();
     let mut db = LearnDb::load(&db_path);
 
@@ -124,7 +125,7 @@ fn ingest_all() {
     for shell in &shells {
         if let Some(path) = shell::history_path(shell) {
             if path.exists() {
-                let count = pattern::ingest_shell_history(&mut db, shell);
+                let count = pattern::ingest_shell_history(&mut db, shell, config);
                 if count > 0 {
                     println!("  {} +{} entries", shell, count);
                     total += count;
@@ -156,7 +157,7 @@ fn ingest_all() {
     }
 }
 
-fn show_stats() {
+fn show_stats(config: &AppConfig) {
     let db_path = learn::db_path();
     let db = LearnDb::load(&db_path);
     let stats = db.stats();
@@ -198,7 +199,11 @@ fn show_stats() {
         let mut all_transitions: Vec<(&String, &String, &u32)> = Vec::new();
         for (from, targets) in &db.transitions {
             for (to, count) in targets {
-                all_transitions.push((from, to, count));
+                if privacy::rejection_reason(from, config).is_none()
+                    && privacy::rejection_reason(to, config).is_none()
+                {
+                    all_transitions.push((from, to, count));
+                }
             }
         }
         all_transitions.sort_by(|a, b| b.2.cmp(a.2));
@@ -257,7 +262,10 @@ fn predict(shell: &ShellKind, config: &AppConfig, n: usize) {
 
     if local_preds.is_empty() {
         // Fall back to Markov chain
-        let markov_preds = markov::markov_blend(&db, &recent, n);
+        let markov_preds: Vec<_> = markov::markov_blend(&db, &recent, n)
+            .into_iter()
+            .filter(|(command, _)| privacy::rejection_reason(command, config).is_none())
+            .collect();
         if markov_preds.is_empty() {
             println!(
                 "{}",
@@ -288,7 +296,7 @@ fn predict(shell: &ShellKind, config: &AppConfig, n: usize) {
     }
 }
 
-fn similar(query: &str, n: usize) {
+fn similar(query: &str, n: usize, config: &AppConfig) {
     let db_path = learn::db_path();
     let db = LearnDb::load(&db_path);
 
@@ -304,7 +312,10 @@ fn similar(query: &str, n: usize) {
     let all_cmds: Vec<&str> = db.trigram_index.keys().map(|s| s.as_str()).collect();
     let idf_weights = trigram::build_idf(&all_cmds);
 
-    let results = trigram::find_similar(query, &db.trigram_index, &idf_weights, n);
+    let results: Vec<_> = trigram::find_similar(query, &db.trigram_index, &idf_weights, n)
+        .into_iter()
+        .filter(|(command, _)| privacy::rejection_reason(command, config).is_none())
+        .collect();
 
     println!(
         "{}",
@@ -333,7 +344,8 @@ fn ask_llm(shell: &ShellKind, config: &AppConfig, n: usize) {
         println!("{}", "To set up LLM predictions, configure:".dimmed());
         println!("  soon config set llm.provider openai    # or 'ollama'");
         println!("  soon config set llm.api_url https://api.openai.com");
-        println!("  soon config set llm.api_key sk-...");
+        println!("  export SOON_LLM_API_KEY from a password manager or hidden prompt");
+        println!("  soon config set llm.api_key_env SOON_LLM_API_KEY  # optional");
         println!("  soon config set llm.model gpt-4o-mini  # optional");
         println!();
         println!("{}", "For Ollama (local, no API key needed):".dimmed());

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -95,7 +95,7 @@ pub fn run(
         println!("  Shell: {}", shell);
         println!("  History commands: {}", history.len());
         if let Some(last) = history.last() {
-            println!("  Last history command: {}", last.cmd);
+            println!("  Last history executable: {}", main_cmd(&last.cmd));
         }
         println!("  Learn DB samples: {}", db.total_samples);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct AppConfig {
     pub llm: LlmConfig,
     #[serde(default)]
     pub events: EventsConfig,
+    #[serde(default)]
+    pub privacy: PrivacyConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,14 +32,14 @@ pub struct UpdateConfig {
     pub channel: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmConfig {
     #[serde(default)]
     pub provider: String,
     #[serde(default)]
     pub api_url: String,
-    #[serde(default)]
-    pub api_key: String,
+    #[serde(default = "default_api_key_env")]
+    pub api_key_env: String,
     #[serde(default)]
     pub model: String,
     #[serde(default)]
@@ -48,6 +50,14 @@ pub struct LlmConfig {
 pub struct EventsConfig {
     #[serde(default = "default_event_retention")]
     pub retention: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PrivacyConfig {
+    #[serde(default)]
+    pub excluded_literals: Vec<String>,
+    #[serde(default)]
+    pub excluded_patterns: Vec<String>,
 }
 
 fn default_shell() -> String {
@@ -64,6 +74,10 @@ fn default_channel() -> String {
 
 fn default_event_retention() -> usize {
     10_000
+}
+
+fn default_api_key_env() -> String {
+    "SOON_LLM_API_KEY".to_string()
 }
 
 fn default_ignored_commands() -> Vec<String> {
@@ -99,6 +113,18 @@ impl Default for EventsConfig {
     fn default() -> Self {
         Self {
             retention: default_event_retention(),
+        }
+    }
+}
+
+impl Default for LlmConfig {
+    fn default() -> Self {
+        Self {
+            provider: String::new(),
+            api_url: String::new(),
+            api_key_env: default_api_key_env(),
+            model: String::new(),
+            prompt: String::new(),
         }
     }
 }
@@ -144,16 +170,17 @@ impl AppConfig {
             "update.channel" => Some(self.update.channel.clone()),
             "llm.provider" => Some(self.llm.provider.clone()),
             "llm.api_url" => Some(self.llm.api_url.clone()),
-            "llm.api_key" => {
-                if self.llm.api_key.is_empty() {
-                    Some(String::new())
-                } else {
-                    Some("****".to_string())
-                }
-            }
+            "llm.api_key_env" => Some(self.llm.api_key_env.clone()),
             "llm.model" => Some(self.llm.model.clone()),
             "llm.prompt" => Some(self.llm.prompt.clone()),
             "events.retention" => Some(self.events.retention.to_string()),
+            "privacy.excluded_literals" => Some(format!(
+                "[{}]",
+                vec!["<redacted>"; self.privacy.excluded_literals.len()].join(", ")
+            )),
+            "privacy.excluded_patterns" => {
+                Some(format!("[{}]", self.privacy.excluded_patterns.join(", ")))
+            }
             _ => None,
         }
     }
@@ -186,7 +213,18 @@ impl AppConfig {
             }
             "llm.provider" => self.llm.provider = value.to_string(),
             "llm.api_url" => self.llm.api_url = value.to_string(),
-            "llm.api_key" => self.llm.api_key = value.to_string(),
+            "llm.api_key" => {
+                return Err(
+                    "Provider credentials are not stored; configure llm.api_key_env and export that environment variable"
+                        .to_string(),
+                );
+            }
+            "llm.api_key_env" => {
+                if !is_valid_env_name(value) {
+                    return Err("Invalid provider credential environment variable name".to_string());
+                }
+                self.llm.api_key_env = value.to_string();
+            }
             "llm.model" => self.llm.model = value.to_string(),
             "llm.prompt" => self.llm.prompt = value.to_string(),
             "events.retention" => {
@@ -198,8 +236,44 @@ impl AppConfig {
                 }
                 self.events.retention = retention;
             }
+            "privacy.excluded_literals" => {
+                self.privacy.excluded_literals = parse_list(value);
+            }
+            "privacy.excluded_patterns" => {
+                let patterns = parse_list(value);
+                if patterns
+                    .iter()
+                    .any(|pattern| regex::Regex::new(pattern).is_err())
+                {
+                    return Err("Invalid privacy exclusion pattern".to_string());
+                }
+                self.privacy.excluded_patterns = patterns;
+            }
             _ => return Err(format!("Unknown config key: {}", key)),
         }
         Ok(())
     }
+
+    pub fn redacted(&self) -> Self {
+        let mut redacted = self.clone();
+        for literal in &mut redacted.privacy.excluded_literals {
+            *literal = "<redacted>".to_string();
+        }
+        redacted
+    }
+}
+
+fn is_valid_env_name(value: &str) -> bool {
+    let mut chars = value.chars();
+    matches!(chars.next(), Some('_' | 'A'..='Z' | 'a'..='z'))
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn parse_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::config::AppConfig;
 use crate::predict::{is_ignored_command, main_cmd};
+use crate::privacy;
 
 pub const SCHEMA_VERSION: u8 = 1;
 
@@ -90,17 +91,23 @@ pub fn event_store_path() -> PathBuf {
         .join("events.jsonl")
 }
 
-pub fn record_command(event: CommandEvent, retention: usize) -> Result<(), String> {
+pub fn record_command(event: CommandEvent, config: &AppConfig) -> Result<(), String> {
     if event.command.trim().is_empty() || event.command.chars().any(char::is_control) {
         return Err("Refusing to store an empty command or control characters".to_string());
     }
+    if let Some(reason) = privacy::rejection_reason(&event.command, config) {
+        return Err(format!("Refusing to store sensitive command: {reason}"));
+    }
 
-    append(&StoredEvent::Command(event), retention)
+    append(&StoredEvent::Command(event), config.events.retention)
 }
 
-pub fn record_suggestion(event: SuggestionEvent, retention: usize) -> Result<(), String> {
+pub fn record_suggestion(event: SuggestionEvent, config: &AppConfig) -> Result<(), String> {
     if event.command.trim().is_empty() || event.command.chars().any(char::is_control) {
         return Err("Refusing to store an empty suggestion or control characters".to_string());
+    }
+    if let Some(reason) = privacy::rejection_reason(&event.command, config) {
+        return Err(format!("Refusing to store sensitive suggestion: {reason}"));
     }
     if !matches!(event.trigger.as_str(), "manual" | "next-step" | "repair") {
         return Err(format!("Unknown prediction trigger: {}", event.trigger));
@@ -111,7 +118,7 @@ pub fn record_suggestion(event: SuggestionEvent, retention: usize) -> Result<(),
     {
         return Err("Invalid suggestion source or latency".to_string());
     }
-    append(&StoredEvent::Suggestion(event), retention)
+    append(&StoredEvent::Suggestion(event), config.events.retention)
 }
 
 pub fn inspect() -> EventStats {
@@ -175,6 +182,7 @@ pub fn predict_after(
             continue;
         };
         if next.command.chars().any(char::is_control)
+            || privacy::rejection_reason(&next.command, config).is_some()
             || is_ignored_command(main_cmd(&next.command), config)
         {
             continue;

--- a/src/learn/llm.rs
+++ b/src/learn/llm.rs
@@ -2,7 +2,7 @@ use crate::config::AppConfig;
 use crate::privacy;
 
 /// LLM-enhanced prediction.
-/// Sends context (recent commands, current dir, time) to a configured LLM
+/// Sends filtered context (recent commands and current directory) to a configured LLM
 /// and parses the JSON response for command predictions.
 pub struct LlmPrediction {
     pub command: String,

--- a/src/learn/llm.rs
+++ b/src/learn/llm.rs
@@ -1,4 +1,5 @@
 use crate::config::AppConfig;
+use crate::privacy;
 
 /// LLM-enhanced prediction.
 /// Sends context (recent commands, current dir, time) to a configured LLM
@@ -15,9 +16,21 @@ pub fn is_configured(config: &AppConfig) -> bool {
 }
 
 /// Build the prompt for the LLM.
-fn build_prompt(recent_cmds: &[&str], current_dir: Option<&str>, custom_prompt: &str) -> String {
-    let cmds_str = recent_cmds.join("\n");
-    let dir_str = current_dir.unwrap_or("unknown");
+fn build_prompt(
+    config: &AppConfig,
+    recent_cmds: &[&str],
+    current_dir: Option<&str>,
+    custom_prompt: &str,
+) -> String {
+    let cmds_str = recent_cmds
+        .iter()
+        .copied()
+        .filter(|command| privacy::rejection_reason(command, config).is_none())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let dir_str = current_dir
+        .filter(|directory| privacy::rejection_reason(directory, config).is_none())
+        .unwrap_or("unknown");
 
     if !custom_prompt.is_empty() {
         return custom_prompt
@@ -51,7 +64,7 @@ pub fn predict(
         return Err("LLM not configured. Use `soon config set llm.provider <provider>` and `soon config set llm.api_url <url>`.".to_string());
     }
 
-    let prompt = build_prompt(recent_cmds, current_dir, &config.llm.prompt);
+    let prompt = build_prompt(config, recent_cmds, current_dir, &config.llm.prompt);
 
     let api_url = config.llm.api_url.trim_end_matches('/');
     let url = match config.llm.provider.as_str() {
@@ -81,8 +94,10 @@ pub fn predict(
 
     let mut req = ureq::post(&url).header("Content-Type", "application/json");
 
-    if !config.llm.api_key.is_empty() {
-        req = req.header("Authorization", &format!("Bearer {}", config.llm.api_key));
+    if let Ok(api_key) = std::env::var(&config.llm.api_key_env) {
+        if !api_key.is_empty() {
+            req = req.header("Authorization", &format!("Bearer {api_key}"));
+        }
     }
 
     let mut response = req
@@ -101,7 +116,7 @@ pub fn predict(
     let content = extract_content(&body, &config.llm.provider)?;
 
     // Parse predictions from the content
-    parse_predictions(&content)
+    parse_predictions(config, &content)
 }
 
 /// Extract the message content from different API response formats.
@@ -127,7 +142,7 @@ fn extract_content(body: &serde_json::Value, provider: &str) -> Result<String, S
 }
 
 /// Parse predictions from the LLM's JSON output.
-fn parse_predictions(content: &str) -> Result<Vec<LlmPrediction>, String> {
+fn parse_predictions(config: &AppConfig, content: &str) -> Result<Vec<LlmPrediction>, String> {
     // Try to find JSON in the content (LLM might wrap it in markdown etc.)
     let json_str = extract_json_block(content);
 
@@ -156,7 +171,10 @@ fn parse_predictions(content: &str) -> Result<Vec<LlmPrediction>, String> {
             .unwrap_or("")
             .to_string();
 
-        if !command.is_empty() {
+        if !command.is_empty()
+            && !command.chars().any(char::is_control)
+            && privacy::rejection_reason(&command, config).is_none()
+        {
             results.push(LlmPrediction {
                 command,
                 confidence,
@@ -191,4 +209,148 @@ fn extract_json_block(s: &str) -> &str {
         }
     }
     s.trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::thread;
+
+    #[test]
+    fn provider_prompt_omits_sensitive_history() {
+        let prompt = build_prompt(
+            &AppConfig::default(),
+            &[
+                "cargo test --workspace",
+                "export API_TOKEN=history-secret-value",
+            ],
+            Some("/tmp/soon-project"),
+            "",
+        );
+
+        assert!(prompt.contains("cargo test --workspace"), "{prompt}");
+        assert!(!prompt.contains("history-secret-value"), "{prompt}");
+        assert!(!prompt.contains("export API_TOKEN"), "{prompt}");
+    }
+
+    #[test]
+    fn sensitive_model_candidates_are_rejected_before_rendering() {
+        let content = r#"{
+            "predictions": [
+                {"command":"deploy --token model-secret-value","confidence":0.9,"reason":"unsafe"},
+                {"command":"cargo test --workspace","confidence":0.8,"reason":"safe"}
+            ]
+        }"#;
+
+        let predictions =
+            parse_predictions(&AppConfig::default(), content).expect("parse model response");
+
+        assert_eq!(predictions.len(), 1);
+        assert_eq!(predictions[0].command, "cargo test --workspace");
+    }
+
+    #[test]
+    fn provider_request_uses_filtered_payload_and_environment_credential() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock provider");
+        let address = listener.local_addr().expect("mock provider address");
+        let (request_tx, request_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept provider request");
+            let request = read_http_request(&mut stream);
+            request_tx.send(request).expect("capture provider request");
+
+            let model_content = serde_json::json!({
+                "predictions": [
+                    {
+                        "command": "deploy --token model-secret-value",
+                        "confidence": 0.9,
+                        "reason": "unsafe"
+                    },
+                    {
+                        "command": "cargo test --workspace",
+                        "confidence": 0.8,
+                        "reason": "safe"
+                    }
+                ]
+            })
+            .to_string();
+            let body = serde_json::json!({
+                "choices": [{"message": {"content": model_content}}]
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write mock provider response");
+        });
+
+        let mut config = AppConfig::default();
+        config.llm.provider = "openai".to_string();
+        config.llm.api_url = format!("http://{address}");
+        config.llm.model = "test-model".to_string();
+        config.llm.api_key_env = format!("SOON_TEST_API_KEY_{}", std::process::id());
+        std::env::set_var(&config.llm.api_key_env, "provider-credential-value");
+
+        let predictions = predict(
+            &config,
+            &[
+                "cargo test --workspace",
+                "export API_TOKEN=history-secret-value",
+            ],
+            Some("/tmp/soon-project"),
+            3,
+        )
+        .expect("request predictions from mock provider");
+        std::env::remove_var(&config.llm.api_key_env);
+        let request = request_rx.recv().expect("receive provider request");
+        server.join().expect("join mock provider");
+
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer provider-credential-value"),
+            "{request}"
+        );
+        assert!(request.contains("cargo test --workspace"), "{request}");
+        assert!(!request.contains("history-secret-value"), "{request}");
+        assert_eq!(predictions.len(), 1);
+        assert_eq!(predictions[0].command, "cargo test --workspace");
+    }
+
+    fn read_http_request(stream: &mut std::net::TcpStream) -> String {
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 4096];
+        loop {
+            let read = stream.read(&mut chunk).expect("read provider request");
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&chunk[..read]);
+
+            let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if request.len() >= header_end + 4 + content_length {
+                break;
+            }
+        }
+        String::from_utf8(request).expect("UTF-8 provider request")
+    }
 }

--- a/src/learn/pattern.rs
+++ b/src/learn/pattern.rs
@@ -3,12 +3,13 @@ use chrono::{Datelike, Local};
 use crate::config::AppConfig;
 use crate::learn::db::LearnDb;
 use crate::learn::trigram;
-use crate::predict::main_cmd;
+use crate::predict::{is_ignored_command, main_cmd};
+use crate::privacy;
 use crate::shell::{self, HistoryItem, ShellKind};
 
 /// Ingest history from a single shell into the learn database.
 /// Returns the number of new entries ingested.
-pub fn ingest_shell_history(db: &mut LearnDb, shell: &ShellKind) -> usize {
+pub fn ingest_shell_history(db: &mut LearnDb, shell: &ShellKind, config: &AppConfig) -> usize {
     let history = shell::load_history(shell);
     if history.is_empty() {
         return 0;
@@ -22,7 +23,7 @@ pub fn ingest_shell_history(db: &mut LearnDb, shell: &ShellKind) -> usize {
     }
 
     let new_entries = &history[cursor..];
-    let count = ingest_entries(db, new_entries);
+    let count = ingest_entries(db, new_entries, config);
 
     db.shell_cursors.insert(shell_name, history.len());
     count
@@ -30,7 +31,7 @@ pub fn ingest_shell_history(db: &mut LearnDb, shell: &ShellKind) -> usize {
 
 /// Ingest history from ALL known shells.
 #[allow(dead_code)]
-pub fn ingest_all_shells(db: &mut LearnDb) -> usize {
+pub fn ingest_all_shells(db: &mut LearnDb, config: &AppConfig) -> usize {
     let shells = [
         ShellKind::Bash,
         ShellKind::Zsh,
@@ -47,14 +48,14 @@ pub fn ingest_all_shells(db: &mut LearnDb) -> usize {
             .map(|p| p.exists())
             .unwrap_or(false)
         {
-            total += ingest_shell_history(db, shell);
+            total += ingest_shell_history(db, shell, config);
         }
     }
     total
 }
 
 /// Core ingestion: process a slice of HistoryItems and record patterns.
-fn ingest_entries(db: &mut LearnDb, entries: &[HistoryItem]) -> usize {
+fn ingest_entries(db: &mut LearnDb, entries: &[HistoryItem], config: &AppConfig) -> usize {
     if entries.is_empty() {
         return 0;
     }
@@ -63,14 +64,23 @@ fn ingest_entries(db: &mut LearnDb, entries: &[HistoryItem]) -> usize {
     let hour = now.format("%H").to_string().parse::<u8>().unwrap_or(0);
     let weekday = now.weekday().num_days_from_monday() as u8;
 
-    let cmds: Vec<&str> = entries.iter().map(|e| main_cmd(&e.cmd)).collect();
+    let cmds: Vec<Option<&str>> = entries
+        .iter()
+        .map(|entry| {
+            if privacy::rejection_reason(&entry.cmd, config).is_some() {
+                None
+            } else {
+                let command = main_cmd(&entry.cmd);
+                (!command.is_empty()).then_some(command)
+            }
+        })
+        .collect();
     let mut count = 0;
 
     for i in 0..cmds.len() {
-        let cmd = cmds[i];
-        if cmd.is_empty() {
+        let Some(cmd) = cmds[i] else {
             continue;
-        }
+        };
 
         // Time and weekday patterns
         db.record_time_pattern(hour, cmd);
@@ -84,13 +94,18 @@ fn ingest_entries(db: &mut LearnDb, entries: &[HistoryItem]) -> usize {
         }
 
         // Single transition: cmds[i] -> cmds[i+1]
-        if i + 1 < cmds.len() && !cmds[i + 1].is_empty() {
-            db.record_transition(cmd, cmds[i + 1]);
+        if let Some(next) = cmds.get(i + 1).copied().flatten() {
+            db.record_transition(cmd, next);
         }
 
         // Bigram transition: (cmds[i-1], cmds[i]) -> cmds[i+1]
-        if i >= 1 && i + 1 < cmds.len() && !cmds[i + 1].is_empty() {
-            db.record_bigram_transition(cmds[i - 1], cmd, cmds[i + 1]);
+        if i >= 1 {
+            if let (Some(previous), Some(next)) = (
+                cmds.get(i - 1).copied().flatten(),
+                cmds.get(i + 1).copied().flatten(),
+            ) {
+                db.record_bigram_transition(previous, cmd, next);
+            }
         }
 
         count += 1;
@@ -184,13 +199,56 @@ pub fn predict_local(
     }
 
     // Filter out ignored commands and recently used commands
-    let ignored = &config.general.ignored_commands;
     scores.retain(|cmd, _| {
-        !ignored.iter().any(|ig| ig == cmd) && recent_cmds.last().is_none_or(|&last| last != cmd)
+        privacy::rejection_reason(cmd, config).is_none()
+            && !is_ignored_command(main_cmd(cmd), config)
+            && recent_cmds.last().is_none_or(|&last| last != cmd)
     });
 
     let mut results: Vec<(String, f64)> = scores.into_iter().collect();
     results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     results.truncate(n);
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_sensitive_candidates_already_present_in_the_learn_database() {
+        let mut db = LearnDb::default();
+        db.record_transition("git", "deploy --token legacy-secret-value");
+        db.record_transition("git", "cargo test --workspace");
+
+        let predictions = predict_local(&db, &["git"], None, &AppConfig::default(), 3);
+
+        assert_eq!(
+            predictions
+                .iter()
+                .map(|(command, _)| command.as_str())
+                .collect::<Vec<_>>(),
+            vec!["cargo test --workspace"]
+        );
+    }
+
+    #[test]
+    fn skips_sensitive_history_entries_before_learning_patterns() {
+        let mut db = LearnDb::default();
+        let entries = vec![
+            HistoryItem {
+                cmd: "export API_TOKEN=secret-history-value".to_string(),
+                path: Some("/tmp/soon-project".to_string()),
+            },
+            HistoryItem {
+                cmd: "cargo test --workspace".to_string(),
+                path: Some("/tmp/soon-project".to_string()),
+            },
+        ];
+
+        let ingested = ingest_entries(&mut db, &entries, &AppConfig::default());
+
+        assert_eq!(ingested, 1);
+        assert_eq!(db.total_samples, 1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod events;
 mod learn;
 mod predict;
+mod privacy;
 mod shell;
 
 use clap::Parser;

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::config::AppConfig;
+use crate::privacy;
 use crate::shell::HistoryItem;
 
 #[derive(Debug, Default)]
@@ -78,7 +79,10 @@ pub fn predict_next_command(
         if match_ratio >= 0.4 && next_idx < history_len {
             let next_cmd = history[next_idx].cmd.trim();
 
-            if !next_cmd.is_empty() && !is_ignored_command(main_cmd(next_cmd), config) {
+            if !next_cmd.is_empty()
+                && privacy::rejection_reason(next_cmd, config).is_none()
+                && !is_ignored_command(main_cmd(next_cmd), config)
+            {
                 let weighted_score = match_ratio * position_weight;
                 let entry = candidates.entry(next_cmd).or_default();
                 entry.total += weighted_score;
@@ -229,5 +233,30 @@ mod tests {
         let prediction = predict_next_command(&history, 1, &["git".to_string()], &config, false);
 
         assert_eq!(prediction, None);
+    }
+
+    #[test]
+    fn rejects_sensitive_candidates_loaded_from_shell_history() {
+        let history = vec![
+            item("git status"),
+            item("export API_TOKEN=secret-history-value"),
+            item("echo separator"),
+            item("git diff"),
+            item("export API_TOKEN=secret-history-value"),
+            item("echo another-separator"),
+            item("git log"),
+            item("cargo test --workspace"),
+            item("echo done"),
+        ];
+
+        let prediction = predict_next_command(
+            &history,
+            1,
+            &["git".to_string()],
+            &config_without_ignores(),
+            false,
+        );
+
+        assert_eq!(prediction.as_deref(), Some("cargo test --workspace"));
     }
 }

--- a/src/privacy.rs
+++ b/src/privacy.rs
@@ -1,0 +1,93 @@
+use regex::{Regex, RegexSet};
+use std::sync::OnceLock;
+
+use crate::config::AppConfig;
+
+pub fn rejection_reason(command: &str, config: &AppConfig) -> Option<&'static str> {
+    if config
+        .privacy
+        .excluded_literals
+        .iter()
+        .filter(|literal| !literal.is_empty())
+        .any(|literal| command.contains(literal))
+    {
+        return Some("configured literal exclusion");
+    }
+    if config
+        .privacy
+        .excluded_patterns
+        .iter()
+        .filter_map(|pattern| Regex::new(pattern).ok())
+        .any(|pattern| pattern.is_match(command))
+    {
+        return Some("configured pattern exclusion");
+    }
+
+    built_in_rejection_reason(command)
+}
+
+fn built_in_rejection_reason(command: &str) -> Option<&'static str> {
+    let normalized = command.to_ascii_lowercase();
+
+    if normalized.contains("-----begin ") && normalized.contains(" private key-----") {
+        return Some("private key material");
+    }
+    if normalized.contains("authorization:") && normalized.contains("bearer ") {
+        return Some("authorization credential");
+    }
+    if secret_patterns().is_match(command) {
+        return Some("inline credential");
+    }
+
+    None
+}
+
+fn secret_patterns() -> &'static RegexSet {
+    static PATTERNS: OnceLock<RegexSet> = OnceLock::new();
+    PATTERNS.get_or_init(|| {
+        RegexSet::new([
+            r#"(?i)(?:^|[\s;&|])(?:export\s+)?[a-z0-9_]*(?:api[_-]?key|token|secret|password|passwd|client[_-]?secret|access[_-]?key)[a-z0-9_]*\s*=\s*['\"]?[^\s'\"]+"#,
+            r#"(?i)(?:^|\s)--(?:api[-_]?key|token|secret|password|passwd|client[-_]?secret)(?:\s+|=)\s*['\"]?[^\s'\"]+"#,
+            r"(?i)(?:^|[^a-z0-9_])(?:sk-[a-z0-9_-]{8,}|github_pat_[a-z0-9_]+|gh[pousr]_[a-z0-9_]{8,}|xox[baprs]-[a-z0-9-]{8,})",
+        ])
+        .expect("built-in privacy patterns must compile")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_common_inline_secrets_without_keyword_false_positives() {
+        let sensitive = [
+            "export OPENAI_API_KEY='sk-live-example'",
+            "curl --header 'Authorization: Bearer abc123' https://example.test",
+            "docker login --password hunter2 registry.example.test",
+            "mysql --password=correct-horse-battery-staple",
+            "printf '%s' 'github_pat_example' | gh auth login --with-token",
+            "-----BEGIN OPENSSH PRIVATE KEY-----",
+        ];
+        for command in sensitive {
+            assert!(
+                rejection_reason(command, &AppConfig::default()).is_some(),
+                "expected sensitive command: {command}"
+            );
+        }
+
+        let safe = [
+            "rg token src",
+            "cargo test password_parser",
+            "git log --grep api_key",
+            "gh auth login --with-token",
+            "op read op://team/registry/password",
+        ];
+        for command in safe {
+            assert_eq!(
+                rejection_reason(command, &AppConfig::default()),
+                None,
+                "unexpected rejection: {command}"
+            );
+        }
+    }
+}

--- a/tests/events_cli.rs
+++ b/tests/events_cli.rs
@@ -1,14 +1,20 @@
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_HOME: AtomicU64 = AtomicU64::new(0);
 
 fn isolated_home() -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock")
         .as_nanos();
-    let path =
-        std::env::temp_dir().join(format!("soon-events-test-{}-{nonce}", std::process::id()));
+    let sequence = NEXT_HOME.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "soon-events-test-{}-{nonce}-{sequence}",
+        std::process::id()
+    ));
     std::fs::create_dir_all(&path).expect("create isolated home");
     path
 }
@@ -65,7 +71,7 @@ fn record_command(
 #[test]
 fn recorded_command_is_counted_without_leaking_its_text() {
     let home = isolated_home();
-    let secret_marker = "cargo test --workspace --token should-not-be-printed";
+    let secret_marker = "cargo test --workspace --label should-not-be-printed";
 
     let record = soon(&home)
         .args([
@@ -222,7 +228,7 @@ fn clearing_events_requires_confirmation_and_empties_the_store() {
 #[test]
 fn suggestion_feedback_outcomes_are_counted_without_leaking_candidates() {
     let home = isolated_home();
-    let candidate = "deploy --token should-not-be-printed";
+    let candidate = "deploy --label should-not-be-printed";
 
     for outcome in ["shown", "accepted", "executed", "dismissed"] {
         let output = soon(&home)
@@ -340,4 +346,442 @@ fn a_truncated_final_line_does_not_corrupt_the_next_event() {
     let _ = std::fs::remove_dir_all(&home);
     assert!(stdout.contains("Command events: 1"), "{stdout}");
     assert!(stdout.contains("Malformed lines: 1"), "{stdout}");
+}
+
+#[test]
+fn sensitive_commands_are_rejected_before_persistence() {
+    let home = isolated_home();
+    let secret = "super-secret-value";
+    let command = format!("curl -H 'Authorization: Bearer {secret}' https://example.test");
+
+    let record = soon(&home)
+        .args([
+            "events",
+            "record-command",
+            "--id",
+            "secret-command",
+            "--command",
+            &command,
+            "--cwd",
+            "/tmp/soon-project",
+            "--started-at-ms",
+            "1000",
+            "--duration-ms",
+            "25",
+            "--exit-code",
+            "0",
+            "--shell",
+            "zsh",
+        ])
+        .output()
+        .expect("reject sensitive command event");
+
+    assert!(!record.status.success(), "sensitive command was persisted");
+    assert!(record.stdout.is_empty(), "rejection wrote to stdout");
+    assert!(
+        !String::from_utf8_lossy(&record.stderr).contains(secret),
+        "rejection leaked the secret"
+    );
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect event store");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Command events: 0"), "{stdout}");
+}
+
+#[test]
+fn sensitive_suggestions_are_rejected_before_persistence() {
+    let home = isolated_home();
+    let secret = "should-not-be-stored";
+    let command = format!("deploy --token {secret}");
+
+    let record = soon(&home)
+        .args([
+            "events",
+            "record-suggestion",
+            "--id",
+            "secret-suggestion",
+            "--trigger",
+            "repair",
+            "--candidate-source",
+            "model",
+            "--command",
+            &command,
+            "--outcome",
+            "shown",
+            "--latency-ms",
+            "12.5",
+        ])
+        .output()
+        .expect("reject sensitive suggestion event");
+
+    assert!(
+        !record.status.success(),
+        "sensitive suggestion was persisted"
+    );
+    assert!(record.stdout.is_empty(), "rejection wrote to stdout");
+    assert!(
+        !String::from_utf8_lossy(&record.stderr).contains(secret),
+        "rejection leaked the secret"
+    );
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect event store");
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Suggestion events: 0"), "{stdout}");
+}
+
+#[test]
+fn previously_stored_sensitive_events_are_not_suggested() {
+    let home = isolated_home();
+    let secret = "legacy-secret-value";
+    std::fs::write(
+        home.join(".zsh_history"),
+        "cargo test\necho safe-fallback\ncargo test\necho safe-fallback\n",
+    )
+    .expect("write Zsh history");
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect event path");
+    let inspect_stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+    let event_path = inspect_stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Event store: "))
+        .map(PathBuf::from)
+        .expect("event store path");
+    std::fs::create_dir_all(event_path.parent().expect("event parent"))
+        .expect("create event directory");
+
+    let first = serde_json::json!({
+        "kind": "command",
+        "schema_version": 1,
+        "id": "legacy-command",
+        "command": "cargo test",
+        "cwd": "/tmp/soon-project",
+        "started_at_ms": 1000,
+        "duration_ms": 25,
+        "exit_code": 0,
+        "shell": "zsh",
+        "previous_event_id": null
+    });
+    let second = serde_json::json!({
+        "kind": "command",
+        "schema_version": 1,
+        "id": "legacy-sensitive-successor",
+        "command": format!("deploy --token {secret}"),
+        "cwd": "/tmp/soon-project",
+        "started_at_ms": 2000,
+        "duration_ms": 25,
+        "exit_code": 0,
+        "shell": "zsh",
+        "previous_event_id": "legacy-command"
+    });
+    std::fs::write(&event_path, format!("{first}\n{second}\n")).expect("seed legacy event store");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict from legacy events");
+    let stdout = String::from_utf8(prediction.stdout).expect("UTF-8 prediction");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        prediction.status.success(),
+        "prediction failed: {}",
+        String::from_utf8_lossy(&prediction.stderr)
+    );
+    assert_eq!(stdout, "echo safe-fallback\n");
+    assert!(!stdout.contains(secret), "prediction leaked a secret");
+}
+
+#[test]
+fn configured_literal_exclusions_reject_commands_without_echoing_values() {
+    let home = isolated_home();
+    let excluded = "internal-deploy --production";
+
+    let configure = soon(&home)
+        .args(["config", "set", "privacy.excluded_literals", excluded])
+        .output()
+        .expect("configure literal exclusion");
+    assert!(
+        configure.status.success(),
+        "configure failed: {}",
+        String::from_utf8_lossy(&configure.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&configure.stdout).contains(excluded),
+        "configuration output leaked excluded literal"
+    );
+
+    let record = soon(&home)
+        .args([
+            "events",
+            "record-command",
+            "--id",
+            "excluded-command",
+            "--command",
+            &format!("{excluded} --region local"),
+            "--cwd",
+            "/tmp/soon-project",
+            "--started-at-ms",
+            "1000",
+            "--duration-ms",
+            "25",
+            "--exit-code",
+            "0",
+            "--shell",
+            "zsh",
+        ])
+        .output()
+        .expect("reject configured exclusion");
+    assert!(!record.status.success(), "excluded command was persisted");
+    assert!(
+        !String::from_utf8_lossy(&record.stderr).contains(excluded),
+        "rejection leaked excluded literal"
+    );
+
+    let show = soon(&home)
+        .arg("config")
+        .output()
+        .expect("show redacted config");
+    let stdout = String::from_utf8(show.stdout).expect("UTF-8 config output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(show.status.success(), "config display failed");
+    assert!(!stdout.contains(excluded), "config display leaked literal");
+    assert!(
+        stdout.contains("excluded_literals = [\"<redacted>\"]"),
+        "{stdout}"
+    );
+}
+
+#[test]
+fn configured_pattern_exclusions_are_validated_and_enforced() {
+    let home = isolated_home();
+    let pattern = r"(?i)^kubectl .*--context production";
+
+    let configure = soon(&home)
+        .args(["config", "set", "privacy.excluded_patterns", pattern])
+        .output()
+        .expect("configure pattern exclusion");
+    assert!(
+        configure.status.success(),
+        "configure failed: {}",
+        String::from_utf8_lossy(&configure.stderr)
+    );
+
+    let record = soon(&home)
+        .args([
+            "events",
+            "record-command",
+            "--id",
+            "excluded-pattern-command",
+            "--command",
+            "kubectl get pods --context production",
+            "--cwd",
+            "/tmp/soon-project",
+            "--started-at-ms",
+            "1000",
+            "--duration-ms",
+            "25",
+            "--exit-code",
+            "0",
+            "--shell",
+            "zsh",
+        ])
+        .output()
+        .expect("reject pattern exclusion");
+    assert!(!record.status.success(), "pattern exclusion was ignored");
+
+    let invalid = soon(&home)
+        .args(["config", "set", "privacy.excluded_patterns", "["])
+        .output()
+        .expect("validate pattern exclusion");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(!invalid.status.success(), "invalid regex was accepted");
+    assert!(
+        String::from_utf8_lossy(&invalid.stderr).contains("Invalid privacy exclusion pattern"),
+        "{}",
+        String::from_utf8_lossy(&invalid.stderr)
+    );
+}
+
+#[test]
+fn provider_credentials_use_an_environment_variable_name() {
+    let home = isolated_home();
+    let secret = "legacy-config-secret";
+
+    let legacy = soon(&home)
+        .args(["config", "set", "llm.api_key", secret])
+        .output()
+        .expect("reject legacy credential storage");
+    assert!(!legacy.status.success(), "stored a provider credential");
+    let legacy_stderr = String::from_utf8_lossy(&legacy.stderr);
+    assert!(!legacy_stderr.contains(secret), "error leaked credential");
+    assert!(legacy_stderr.contains("llm.api_key_env"), "{legacy_stderr}");
+
+    let configure = soon(&home)
+        .args(["config", "set", "llm.api_key_env", "TEAM_PROVIDER_TOKEN"])
+        .output()
+        .expect("configure provider credential environment variable");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        configure.status.success(),
+        "environment variable configuration failed: {}",
+        String::from_utf8_lossy(&configure.stderr)
+    );
+}
+
+#[test]
+fn learn_statistics_do_not_render_sensitive_legacy_entries() {
+    let home = isolated_home();
+    let secret = "legacy-learn-secret";
+    let config_path = soon(&home)
+        .args(["config", "path"])
+        .output()
+        .expect("get config path");
+    let learn_path = PathBuf::from(
+        String::from_utf8(config_path.stdout)
+            .expect("UTF-8 config path")
+            .trim(),
+    )
+    .parent()
+    .expect("config parent")
+    .join("learn.json");
+    std::fs::create_dir_all(learn_path.parent().expect("learn parent"))
+        .expect("create learn directory");
+    let learn_db = serde_json::json!({
+        "transitions": {
+            "git": {
+                format!("deploy --token {secret}"): 3,
+                "cargo test --workspace": 1
+            }
+        },
+        "total_samples": 4
+    });
+    std::fs::write(&learn_path, learn_db.to_string()).expect("seed legacy learn database");
+
+    let stats = soon(&home)
+        .args(["learn", "stats"])
+        .output()
+        .expect("show learn statistics");
+    let stdout = String::from_utf8(stats.stdout).expect("UTF-8 learn statistics");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        stats.status.success(),
+        "learn stats failed: {}",
+        String::from_utf8_lossy(&stats.stderr)
+    );
+    assert!(!stdout.contains(secret), "learn stats leaked a secret");
+    assert!(!stdout.contains("deploy --token"), "{stdout}");
+    assert!(stdout.contains("cargo test --workspace"), "{stdout}");
+}
+
+#[test]
+fn similar_search_does_not_render_sensitive_legacy_entries() {
+    let home = isolated_home();
+    let secret = "legacy-similar-secret";
+    let config_path = soon(&home)
+        .args(["config", "path"])
+        .output()
+        .expect("get config path");
+    let learn_path = PathBuf::from(
+        String::from_utf8(config_path.stdout)
+            .expect("UTF-8 config path")
+            .trim(),
+    )
+    .parent()
+    .expect("config parent")
+    .join("learn.json");
+    std::fs::create_dir_all(learn_path.parent().expect("learn parent"))
+        .expect("create learn directory");
+    let learn_db = serde_json::json!({
+        "trigram_index": {
+            format!("deploy --token {secret}"): {"$de": 1.0}
+        },
+        "total_samples": 1
+    });
+    std::fs::write(&learn_path, learn_db.to_string()).expect("seed legacy learn database");
+
+    let similar = soon(&home)
+        .args(["learn", "similar", "deploy"])
+        .output()
+        .expect("search legacy learn database");
+    let stdout = String::from_utf8(similar.stdout).expect("UTF-8 similar output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        similar.status.success(),
+        "similar search failed: {}",
+        String::from_utf8_lossy(&similar.stderr)
+    );
+    assert!(!stdout.contains(secret), "similar search leaked a secret");
+    assert!(!stdout.contains("deploy --token"), "{stdout}");
+}
+
+#[test]
+fn markov_fallback_does_not_render_sensitive_legacy_entries() {
+    let home = isolated_home();
+    let secret = "legacy-markov-secret";
+    std::fs::write(home.join(".zsh_history"), "git status\n").expect("write Zsh history");
+    let config_path = soon(&home)
+        .args(["config", "path"])
+        .output()
+        .expect("get config path");
+    let learn_path = PathBuf::from(
+        String::from_utf8(config_path.stdout)
+            .expect("UTF-8 config path")
+            .trim(),
+    )
+    .parent()
+    .expect("config parent")
+    .join("learn.json");
+    std::fs::create_dir_all(learn_path.parent().expect("learn parent"))
+        .expect("create learn directory");
+    let learn_db = serde_json::json!({
+        "transitions": {
+            "git": {format!("deploy --token {secret}"): 1}
+        },
+        "total_samples": 1
+    });
+    std::fs::write(&learn_path, learn_db.to_string()).expect("seed legacy learn database");
+
+    let prediction = soon(&home)
+        .args(["--shell", "zsh", "learn", "predict"])
+        .output()
+        .expect("predict from legacy learn database");
+    let stdout = String::from_utf8(prediction.stdout).expect("UTF-8 prediction output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        prediction.status.success(),
+        "learn prediction failed: {}",
+        String::from_utf8_lossy(&prediction.stderr)
+    );
+    assert!(!stdout.contains(secret), "Markov fallback leaked a secret");
+    assert!(!stdout.contains("deploy --token"), "{stdout}");
 }

--- a/tests/zsh_cli.rs
+++ b/tests/zsh_cli.rs
@@ -1,14 +1,21 @@
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_HOME: AtomicU64 = AtomicU64::new(0);
 
 fn isolated_home() -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock")
         .as_nanos();
-    let path = std::env::temp_dir().join(format!("soon-zsh-test-{}-{nonce}", std::process::id()));
+    let sequence = NEXT_HOME.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "soon-zsh-test-{}-{nonce}-{sequence}",
+        std::process::id()
+    ));
     std::fs::create_dir_all(&path).expect("create isolated home");
     path
 }
@@ -84,4 +91,32 @@ fn raw_prediction_uses_the_submitted_command_as_context() {
         String::from_utf8(output.stdout).expect("UTF-8 prediction"),
         "cargo test --workspace\n"
     );
+}
+
+#[test]
+fn debug_output_does_not_print_sensitive_history_text() {
+    let home = isolated_home();
+    let secret = "debug-secret-value";
+    std::fs::write(
+        home.join(".zsh_history"),
+        format!("cargo test\nexport API_TOKEN={secret}\n"),
+    )
+    .expect("write Zsh history");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soon"))
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .args(["--shell", "zsh", "--debug", "now"])
+        .output()
+        .expect("run debug prediction");
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 debug output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        output.status.success(),
+        "debug prediction failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!stdout.contains(secret), "debug output leaked a secret");
+    assert!(!stdout.contains("export API_TOKEN="), "{stdout}");
 }


### PR DESCRIPTION
## Summary

- reject likely inline credentials and configured exclusions before command or suggestion persistence
- apply the same policy to shell history, legacy event/learn data, provider payloads, and model output
- read provider credentials from a named environment variable instead of storing them in config
- redact literal exclusions and keep debug/inspection output free of raw sensitive history
- document the filter policy, minimal remote payload, retention controls, and credential setup

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (30 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `uvx pre-commit run --all-files`
- `cargo run --locked -- --help`
- `git diff --check origin/master...HEAD`

Closes #9
Refs #4
Refs #17

## Summary by Sourcery

引入隐私过滤层，用于在本地存储和预测流程中拒绝可能敏感的命令和建议，并将 LLM 凭据迁移到基于环境变量的配置方式。

New Features:
- 通过字面量和正则模式为命令和建议添加可配置的隐私排除项。
- 使用共享的敏感命令策略过滤 shell 历史、learn 数据库内容、provider 提示词以及模型输出。
- 通过新的 `llm.api_key_env` 设置支持基于环境变量的 provider API 密钥配置。

Enhancements:
- 更新本地和基于 LLM 的预测流水线，以跳过敏感候选项，并避免在调试和检查输出中泄露机密信息。
- 扩展配置处理逻辑，提供隐私排除项的脱敏视图，并对与凭据相关的设置实施更严格的校验。

Documentation:
- 编写文档，说明隐私过滤行为、排除项的配置选项、远程负载最小化策略，以及基于环境变量的 LLM 凭据配置方法。

Tests:
- 添加全面测试，用于覆盖敏感命令和建议的拒绝、对旧版 learn 和事件数据的清理、对 provider 提示及响应的过滤，以及不泄露信息的调试/配置输出。
- 强化 CLI 测试，通过在每次运行中隔离 `HOME` 目录来避免测试之间的相互干扰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a privacy filtering layer that rejects likely sensitive commands and suggestions across local storage and prediction, and move LLM credentials to environment-based configuration.

New Features:
- Add configurable privacy exclusions for commands and suggestions via literal and regex patterns.
- Filter shell history, learn database content, provider prompts, and model outputs using a shared sensitive-command policy.
- Support environment-variable-based provider API keys through the new llm.api_key_env setting.

Enhancements:
- Update local and LLM-backed prediction pipelines to skip sensitive candidates and avoid leaking secrets in debug and inspection output.
- Extend config handling with redacted views of privacy exclusions and stricter validation of credential-related settings.

Documentation:
- Document the privacy filter behavior, configuration options for exclusions, remote payload minimization, and environment-based LLM credential setup.

Tests:
- Add extensive tests covering rejection of sensitive commands and suggestions, sanitization of legacy learn and event data, filtering of provider prompts and responses, and non-leaking debug/config output.
- Harden CLI tests by isolating HOME per run to avoid cross-test interference.

</details>