### PR TITLE
feat: import Zsh history into event memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and t
 | Current source | v0.4 target |
 |---|---|
 | On-demand command plus opt-in Zsh loop | Coherent beta install and clean-session smoke test |
-| Manual, successful-command Next-step, and failed-command Repair triggers | Useful cold starts from a safe history import |
+| Manual, successful-command Next-step, and failed-command Repair triggers | Clean-session lifecycle regression coverage |
 | Retained command and suggestion events with feedback | Local replay quality and latency metrics |
-| Built-in and user-configured sensitive-command filters | A documented v0.4 privacy and release audit |
+| Sensitive-command filters plus idempotent Zsh history import | A documented v0.4 privacy and release audit |
 
 The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). Work is tracked in the public [Personal Terminal Agent Project](https://github.com/users/HsiangNianian/projects/7).
 
@@ -129,7 +129,7 @@ This baseline is deliberately simple. A more complex ranker must beat it on the 
 
 ## Agent roadmap
 
-The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) adds safe command lifecycle events and three prediction triggers: explicit `soon`, Next-step after success, and Repair after failure.
+The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) combines safe command lifecycle events, explicit `soon`, Next-step after success, Repair after failure, and a private history-import path. The remaining gate is measured local replay plus a coherent beta release.
 
 The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) then measures a contextual probabilistic ranker in [#16](https://github.com/HsiangNianian/soon/issues/16) before adding opt-in local-model and OpenAI-compatible candidate sources in [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
 
@@ -175,6 +175,24 @@ soon config set events.retention 5000
 soon events clear --yes
 ```
 
+Give a fresh profile useful event memory by previewing a Zsh history import first:
+
+```bash
+# Uses ~/.zsh_history
+soon events import-zsh --preview
+soon events import-zsh
+
+# Or pass current and rotated files explicitly, oldest first
+soon events import-zsh --preview \
+  --path ~/.zsh_history.1 \
+  --path ~/.zsh_history
+soon events import-zsh \
+  --path ~/.zsh_history.1 \
+  --path ~/.zsh_history
+```
+
+Plain command-per-line history and Zsh extended history (`: <epoch>:<duration>;<command>`) are supported. Extended timestamps and durations are preserved; unavailable cwd, exit status, and plain-history timestamps remain unknown. Preview and import summaries report importable, sensitive, malformed, duplicate, and already-imported counts without printing command text. Stable event IDs make repeated imports idempotent, including identical rotated files.
+
 Config lives at `~/.config/soon/config.toml`:
 
 ```bash
@@ -193,7 +211,7 @@ soon init zsh           Print the opt-in Zsh integration
 soon stats              Show the most-used executables
 soon which              Show shell and history diagnostics
 soon config             View or change local configuration
-soon events             Inspect or clear local agent events
+soon events             Inspect, clear, or import local agent events
 soon learn              Use the experimental learning tools
 soon update             Check the configured release channel
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -71,6 +72,15 @@ pub enum EventsAction {
         /// Confirm permanent removal
         #[arg(long)]
         yes: bool,
+    },
+    /// Preview or import Zsh history into the local event store
+    ImportZsh {
+        /// History file to import; repeat for rotated files
+        #[arg(long, value_name = "PATH")]
+        path: Vec<PathBuf>,
+        /// Report counts without writing events
+        #[arg(long)]
+        preview: bool,
     },
     /// Record one completed command event (used by shell integrations)
     #[command(hide = true)]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,11 +1,14 @@
 use crate::cli::EventsAction;
 use crate::config::AppConfig;
 use crate::events::{self, CommandEvent, SuggestionEvent, SuggestionOutcome, SCHEMA_VERSION};
+use crate::history_import;
+use crate::shell::{self, ShellKind};
 
 pub fn run(action: EventsAction, config: &AppConfig) {
     match action {
         EventsAction::Inspect => inspect(config.events.retention),
         EventsAction::Clear { yes } => clear(yes),
+        EventsAction::ImportZsh { path, preview } => import_zsh(path, preview, config),
         EventsAction::RecordCommand {
             id,
             command,
@@ -20,10 +23,10 @@ pub fn run(action: EventsAction, config: &AppConfig) {
                 schema_version: SCHEMA_VERSION,
                 id,
                 command,
-                cwd,
-                started_at_ms,
-                duration_ms,
-                exit_code,
+                cwd: Some(cwd),
+                started_at_ms: Some(started_at_ms),
+                duration_ms: Some(duration_ms),
+                exit_code: Some(exit_code),
                 shell,
                 previous_event_id: previous_id,
             },
@@ -56,6 +59,36 @@ pub fn run(action: EventsAction, config: &AppConfig) {
                 config,
             );
         }
+    }
+}
+
+fn import_zsh(mut paths: Vec<std::path::PathBuf>, preview: bool, config: &AppConfig) {
+    if paths.is_empty() {
+        let Some(default_path) = shell::history_path(&ShellKind::Zsh) else {
+            eprintln!("Could not resolve the default Zsh history path");
+            std::process::exit(1);
+        };
+        paths.push(default_path);
+    }
+
+    let stats = history_import::import_zsh(&paths, config, preview).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        std::process::exit(1);
+    });
+    println!(
+        "Zsh history import{}",
+        if preview { " preview" } else { "" }
+    );
+    println!("Files: {}", stats.files);
+    println!("Importable entries: {}", stats.importable);
+    println!("Sensitive entries skipped: {}", stats.sensitive);
+    println!("Malformed entries skipped: {}", stats.malformed);
+    println!("Duplicate entries skipped: {}", stats.duplicates);
+    println!("Already imported: {}", stats.already_imported);
+    if preview {
+        println!("Would import: {}", stats.would_import());
+    } else {
+        println!("Imported: {}", stats.imported);
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -14,10 +15,10 @@ pub struct CommandEvent {
     pub schema_version: u8,
     pub id: String,
     pub command: String,
-    pub cwd: String,
-    pub started_at_ms: i64,
-    pub duration_ms: u64,
-    pub exit_code: i32,
+    pub cwd: Option<String>,
+    pub started_at_ms: Option<i64>,
+    pub duration_ms: Option<u64>,
+    pub exit_code: Option<i32>,
     pub shell: String,
     pub previous_event_id: Option<String>,
 }
@@ -64,6 +65,7 @@ impl SuggestionOutcome {
 
 #[derive(Debug, Default)]
 struct CandidateScore {
+    result_matches: usize,
     evidence: usize,
     directory_matches: usize,
     latest_index: usize,
@@ -92,14 +94,68 @@ pub fn event_store_path() -> PathBuf {
 }
 
 pub fn record_command(event: CommandEvent, config: &AppConfig) -> Result<(), String> {
+    validate_command(&event, config)?;
+
+    append(&StoredEvent::Command(event), config.events.retention)
+}
+
+pub fn existing_command_event_ids() -> HashSet<String> {
+    load_command_events()
+        .into_iter()
+        .map(|event| event.id)
+        .collect()
+}
+
+pub fn import_commands(events: Vec<CommandEvent>, config: &AppConfig) -> Result<usize, String> {
+    if config.events.retention == 0 {
+        return Err("Event retention must be at least 1".to_string());
+    }
+    for event in &events {
+        validate_command(event, config)?;
+    }
+
+    let path = event_store_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create event directory: {error}"))?;
+    }
+    let mut existing = load_stored_events(&path);
+    let mut known_ids: HashSet<String> = existing
+        .iter()
+        .filter_map(|event| match event {
+            StoredEvent::Command(command) => Some(command.id.clone()),
+            StoredEvent::Suggestion(_) => None,
+        })
+        .collect();
+    let new_events: Vec<StoredEvent> = events
+        .into_iter()
+        .filter(|event| known_ids.insert(event.id.clone()))
+        .map(StoredEvent::Command)
+        .collect();
+    let imported = new_events.len();
+    if imported == 0 {
+        return Ok(0);
+    }
+
+    if existing.len() + imported > config.events.retention {
+        existing.extend(new_events);
+        let keep_from = existing.len().saturating_sub(config.events.retention);
+        write_events_atomically(&path, &existing[keep_from..])?;
+    } else {
+        append_many(&path, &new_events)?;
+    }
+
+    Ok(imported)
+}
+
+fn validate_command(event: &CommandEvent, config: &AppConfig) -> Result<(), String> {
     if event.command.trim().is_empty() || event.command.chars().any(char::is_control) {
         return Err("Refusing to store an empty command or control characters".to_string());
     }
     if let Some(reason) = privacy::rejection_reason(&event.command, config) {
         return Err(format!("Refusing to store sensitive command: {reason}"));
     }
-
-    append(&StoredEvent::Command(event), config.events.retention)
+    Ok(())
 }
 
 pub fn record_suggestion(event: SuggestionEvent, config: &AppConfig) -> Result<(), String> {
@@ -174,7 +230,11 @@ pub fn predict_after(
     let wanted_success = exit_code == 0;
 
     for (index, event) in events.iter().enumerate() {
-        if event.command.trim() != command.trim() || (event.exit_code == 0) != wanted_success {
+        if event.command.trim() != command.trim()
+            || event
+                .exit_code
+                .is_some_and(|code| (code == 0) != wanted_success)
+        {
             continue;
         }
 
@@ -189,16 +249,19 @@ pub fn predict_after(
         }
 
         let score = candidates.entry(next.command.clone()).or_default();
+        score.result_matches += usize::from(event.exit_code.is_some());
         score.evidence += 1;
-        score.directory_matches += usize::from(cwd.is_some_and(|cwd| cwd == event.cwd));
+        score.directory_matches +=
+            usize::from(cwd.is_some_and(|cwd| Some(cwd) == event.cwd.as_deref()));
         score.latest_index = index;
     }
 
     let mut ranked: Vec<_> = candidates.into_iter().collect();
     ranked.sort_by(|(command_a, score_a), (command_b, score_b)| {
         score_b
-            .directory_matches
-            .cmp(&score_a.directory_matches)
+            .result_matches
+            .cmp(&score_a.result_matches)
+            .then_with(|| score_b.directory_matches.cmp(&score_a.directory_matches))
             .then_with(|| score_b.evidence.cmp(&score_a.evidence))
             .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
             .then_with(|| command_a.cmp(command_b))
@@ -220,6 +283,52 @@ fn load_command_events() -> Vec<CommandEvent> {
             StoredEvent::Suggestion(_) => None,
         })
         .collect()
+}
+
+fn load_stored_events(path: &std::path::Path) -> Vec<StoredEvent> {
+    File::open(path)
+        .ok()
+        .map(BufReader::new)
+        .into_iter()
+        .flat_map(|reader| reader.lines().map_while(Result::ok))
+        .filter_map(|line| serde_json::from_str::<StoredEvent>(&line).ok())
+        .collect()
+}
+
+fn append_many(path: &std::path::Path, events: &[StoredEvent]) -> Result<(), String> {
+    let needs_separator = fs::read(path)
+        .ok()
+        .and_then(|contents| contents.last().copied())
+        .is_some_and(|last| last != b'\n');
+    let mut encoded = Vec::new();
+    if needs_separator {
+        encoded.push(b'\n');
+    }
+    for event in events {
+        serde_json::to_writer(&mut encoded, event)
+            .map_err(|error| format!("Failed to serialize imported event: {error}"))?;
+        encoded.push(b'\n');
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|error| format!("Failed to open event store: {error}"))?;
+    file.write_all(&encoded)
+        .map_err(|error| format!("Failed to append imported events: {error}"))
+}
+
+fn write_events_atomically(path: &std::path::Path, events: &[StoredEvent]) -> Result<(), String> {
+    let mut encoded = Vec::new();
+    for event in events {
+        serde_json::to_writer(&mut encoded, event)
+            .map_err(|error| format!("Failed to serialize retained event: {error}"))?;
+        encoded.push(b'\n');
+    }
+    let temp_path = path.with_extension(format!("jsonl.tmp-{}", std::process::id()));
+    fs::write(&temp_path, encoded)
+        .map_err(|error| format!("Failed to compact event store: {error}"))?;
+    fs::rename(&temp_path, path).map_err(|error| format!("Failed to replace event store: {error}"))
 }
 
 fn append(event: &StoredEvent, retention: usize) -> Result<(), String> {

--- a/src/history_import.rs
+++ b/src/history_import.rs
@@ -1,0 +1,175 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::config::AppConfig;
+use crate::events::{self, CommandEvent, SCHEMA_VERSION};
+use crate::privacy;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImportStats {
+    pub files: usize,
+    pub importable: usize,
+    pub sensitive: usize,
+    pub malformed: usize,
+    pub duplicates: usize,
+    pub already_imported: usize,
+    pub imported: usize,
+}
+
+impl ImportStats {
+    pub fn would_import(&self) -> usize {
+        self.importable
+            .saturating_sub(self.duplicates)
+            .saturating_sub(self.already_imported)
+    }
+}
+
+pub fn import_zsh(
+    paths: &[PathBuf],
+    config: &AppConfig,
+    preview: bool,
+) -> Result<ImportStats, String> {
+    let (mut stats, mut commands) = prepare_zsh(paths, config)?;
+    let mut seen_ids = HashSet::new();
+    commands.retain(|event| {
+        let is_new = seen_ids.insert(event.id.clone());
+        stats.duplicates += usize::from(!is_new);
+        is_new
+    });
+    let existing_ids = events::existing_command_event_ids();
+    stats.already_imported = commands
+        .iter()
+        .filter(|event| existing_ids.contains(&event.id))
+        .count();
+
+    if !preview {
+        stats.imported = events::import_commands(commands, config)?;
+    }
+
+    Ok(stats)
+}
+
+fn prepare_zsh(
+    paths: &[PathBuf],
+    config: &AppConfig,
+) -> Result<(ImportStats, Vec<CommandEvent>), String> {
+    let mut stats = ImportStats::default();
+    let mut commands = Vec::new();
+
+    for path in paths {
+        let contents = std::fs::read(path)
+            .map_err(|error| format!("Failed to read Zsh history {}: {error}", path.display()))?;
+        stats.files += 1;
+        let mut previous_event_id = None;
+
+        for raw_line in contents.split(|byte| *byte == b'\n') {
+            if raw_line.is_empty() {
+                continue;
+            }
+            let Ok(line) = std::str::from_utf8(raw_line) else {
+                stats.malformed += 1;
+                previous_event_id = None;
+                continue;
+            };
+            match parse_zsh_line(line) {
+                Ok(Some(entry)) => {
+                    if entry.command.chars().any(char::is_control) {
+                        stats.malformed += 1;
+                        previous_event_id = None;
+                        continue;
+                    }
+                    if privacy::rejection_reason(entry.command, config).is_some() {
+                        stats.sensitive += 1;
+                        previous_event_id = None;
+                        continue;
+                    }
+
+                    let id = stable_event_id(&entry, previous_event_id.as_deref());
+                    commands.push(CommandEvent {
+                        schema_version: SCHEMA_VERSION,
+                        id: id.clone(),
+                        command: entry.command.to_string(),
+                        cwd: None,
+                        started_at_ms: entry.started_at_ms,
+                        duration_ms: entry.duration_ms,
+                        exit_code: None,
+                        shell: "zsh".to_string(),
+                        previous_event_id,
+                    });
+                    previous_event_id = Some(id);
+                    stats.importable += 1;
+                }
+                Ok(None) => {}
+                Err(()) => {
+                    stats.malformed += 1;
+                    previous_event_id = None;
+                }
+            }
+        }
+    }
+
+    Ok((stats, commands))
+}
+
+struct ZshEntry<'a> {
+    command: &'a str,
+    started_at_ms: Option<i64>,
+    duration_ms: Option<u64>,
+}
+
+fn parse_zsh_line(line: &str) -> Result<Option<ZshEntry<'_>>, ()> {
+    let line = line.trim();
+    if line.is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(metadata_and_command) = line.strip_prefix(": ") {
+        if let Some((metadata, command)) = metadata_and_command.split_once(';') {
+            if metadata.contains(':') {
+                let (timestamp, duration) = metadata.split_once(':').ok_or(())?;
+                let timestamp = timestamp.parse::<i64>().map_err(|_| ())?;
+                let duration = duration.parse::<u64>().map_err(|_| ())?;
+                let started_at_ms = timestamp.checked_mul(1000).ok_or(())?;
+                let duration_ms = duration.checked_mul(1000).ok_or(())?;
+                let command = command.trim();
+                if command.is_empty() {
+                    return Err(());
+                }
+                return Ok(Some(ZshEntry {
+                    command,
+                    started_at_ms: Some(started_at_ms),
+                    duration_ms: Some(duration_ms),
+                }));
+            }
+        }
+    }
+
+    Ok(Some(ZshEntry {
+        command: line,
+        started_at_ms: None,
+        duration_ms: None,
+    }))
+}
+
+fn stable_event_id(entry: &ZshEntry<'_>, previous_event_id: Option<&str>) -> String {
+    let material = format!(
+        "{}\0{}\0{}\0{}",
+        entry
+            .started_at_ms
+            .map_or_else(String::new, |value| value.to_string()),
+        entry
+            .duration_ms
+            .map_or_else(String::new, |value| value.to_string()),
+        previous_event_id.unwrap_or("root"),
+        entry.command
+    );
+    let first = fnv1a(material.as_bytes(), 0xcbf29ce484222325);
+    let second = fnv1a(material.as_bytes(), 0x84222325cbf29ce4);
+    format!("zsh-import-{first:016x}{second:016x}")
+}
+
+fn fnv1a(bytes: &[u8], seed: u64) -> u64 {
+    bytes.iter().fold(seed, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod commands;
 mod config;
 mod events;
+mod history_import;
 mod learn;
 mod predict;
 mod privacy;

--- a/tests/events_cli.rs
+++ b/tests/events_cli.rs
@@ -785,3 +785,229 @@ fn markov_fallback_does_not_render_sensitive_legacy_entries() {
     assert!(!stdout.contains(secret), "Markov fallback leaked a secret");
     assert!(!stdout.contains("deploy --token"), "{stdout}");
 }
+
+#[test]
+fn zsh_history_import_preview_is_non_mutating_and_private() {
+    let home = isolated_home();
+    let history_path = home.join("history.zsh");
+    let sensitive = "preview-secret-value";
+    let malformed = "malformed-command-must-not-print";
+    std::fs::write(
+        &history_path,
+        format!(
+            "git status\n: 1721811600:12;cargo test --workspace\n: bad:line;{malformed}\nexport API_TOKEN={sensitive}\n"
+        ),
+    )
+    .expect("write Zsh history fixture");
+
+    let preview = soon(&home)
+        .args(["events", "import-zsh", "--path"])
+        .arg(&history_path)
+        .arg("--preview")
+        .output()
+        .expect("preview Zsh history import");
+    let stdout = String::from_utf8(preview.stdout).expect("UTF-8 import preview");
+
+    assert!(
+        preview.status.success(),
+        "preview failed: {}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    assert!(stdout.contains("Importable entries: 2"), "{stdout}");
+    assert!(stdout.contains("Sensitive entries skipped: 1"), "{stdout}");
+    assert!(stdout.contains("Malformed entries skipped: 1"), "{stdout}");
+    assert!(stdout.contains("Would import: 2"), "{stdout}");
+    assert!(!stdout.contains(sensitive), "preview leaked sensitive text");
+    assert!(!stdout.contains(malformed), "preview leaked malformed text");
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect after preview");
+    let inspect_stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        inspect_stdout.contains("Command events: 0"),
+        "{inspect_stdout}"
+    );
+}
+
+#[test]
+fn zsh_history_import_is_idempotent_and_preserves_unknown_metadata() {
+    let home = isolated_home();
+    let history_path = home.join("history.zsh");
+    std::fs::write(
+        &history_path,
+        "git status\n: 1721811600:12;cargo test --workspace\n",
+    )
+    .expect("write Zsh history fixture");
+
+    let first = soon(&home)
+        .args(["events", "import-zsh", "--path"])
+        .arg(&history_path)
+        .output()
+        .expect("import Zsh history");
+    assert!(
+        first.status.success(),
+        "first import failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_stdout = String::from_utf8(first.stdout).expect("UTF-8 import output");
+    assert!(first_stdout.contains("Imported: 2"), "{first_stdout}");
+    assert!(
+        first_stdout.contains("Already imported: 0"),
+        "{first_stdout}"
+    );
+
+    let second = soon(&home)
+        .args(["events", "import-zsh", "--path"])
+        .arg(&history_path)
+        .output()
+        .expect("repeat Zsh history import");
+    assert!(
+        second.status.success(),
+        "second import failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_stdout = String::from_utf8(second.stdout).expect("UTF-8 repeated import output");
+    assert!(second_stdout.contains("Imported: 0"), "{second_stdout}");
+    assert!(
+        second_stdout.contains("Already imported: 2"),
+        "{second_stdout}"
+    );
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect imported events");
+    let inspect_stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+    let event_path = inspect_stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Event store: "))
+        .map(PathBuf::from)
+        .expect("event store path");
+    let stored = std::fs::read_to_string(event_path).expect("read imported event store");
+    let events: Vec<serde_json::Value> = stored
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("parse imported event"))
+        .collect();
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        inspect_stdout.contains("Command events: 2"),
+        "{inspect_stdout}"
+    );
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["command"], "git status");
+    assert!(events[0]["cwd"].is_null());
+    assert!(events[0]["started_at_ms"].is_null());
+    assert!(events[0]["duration_ms"].is_null());
+    assert!(events[0]["exit_code"].is_null());
+    assert!(events[0]["previous_event_id"].is_null());
+    assert_eq!(events[1]["command"], "cargo test --workspace");
+    assert_eq!(events[1]["started_at_ms"], 1_721_811_600_000_i64);
+    assert_eq!(events[1]["duration_ms"], 12_000_u64);
+    assert!(events[1]["cwd"].is_null());
+    assert!(events[1]["exit_code"].is_null());
+    assert_eq!(events[1]["previous_event_id"], events[0]["id"]);
+}
+
+#[test]
+fn imported_zsh_history_can_predict_without_the_source_history_file() {
+    let home = isolated_home();
+    let history_path = home.join("cold-start-history.zsh");
+    std::fs::write(&history_path, "git status\ncargo test --workspace\n")
+        .expect("write cold-start history");
+
+    let imported = soon(&home)
+        .args(["events", "import-zsh", "--path"])
+        .arg(&history_path)
+        .output()
+        .expect("import cold-start history");
+    assert!(
+        imported.status.success(),
+        "import failed: {}",
+        String::from_utf8_lossy(&imported.stderr)
+    );
+    std::fs::remove_file(&history_path).expect("remove source history");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "git status",
+            "--exit-code",
+            "0",
+        ])
+        .output()
+        .expect("predict from imported events");
+    let stdout = String::from_utf8(prediction.stdout).expect("UTF-8 prediction");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        prediction.status.success(),
+        "prediction failed: {}",
+        String::from_utf8_lossy(&prediction.stderr)
+    );
+    assert_eq!(stdout, "cargo test --workspace\n");
+}
+
+#[test]
+fn overlapping_rotated_zsh_histories_are_deduplicated() {
+    let home = isolated_home();
+    let current = home.join(".zsh_history");
+    let rotated = home.join(".zsh_history.1");
+    let contents = "git status\ncargo test --workspace\n";
+    std::fs::write(&current, contents).expect("write current Zsh history");
+    std::fs::write(&rotated, contents).expect("write rotated Zsh history");
+
+    let preview = soon(&home)
+        .args(["events", "import-zsh", "--path"])
+        .arg(&rotated)
+        .args(["--path"])
+        .arg(&current)
+        .arg("--preview")
+        .output()
+        .expect("preview overlapping Zsh histories");
+    let preview_stdout = String::from_utf8(preview.stdout).expect("UTF-8 preview");
+    assert!(preview.status.success(), "preview failed");
+    assert!(
+        preview_stdout.contains("Importable entries: 4"),
+        "{preview_stdout}"
+    );
+    assert!(
+        preview_stdout.contains("Duplicate entries skipped: 2"),
+        "{preview_stdout}"
+    );
+    assert!(
+        preview_stdout.contains("Would import: 2"),
+        "{preview_stdout}"
+    );
+
+    let imported = soon(&home)
+        .args(["events", "import-zsh", "--path"])
+        .arg(&rotated)
+        .args(["--path"])
+        .arg(&current)
+        .output()
+        .expect("import overlapping Zsh histories");
+    let import_stdout = String::from_utf8(imported.stdout).expect("UTF-8 import output");
+    assert!(imported.status.success(), "import failed");
+    assert!(import_stdout.contains("Imported: 2"), "{import_stdout}");
+
+    let inspect = soon(&home)
+        .args(["events", "inspect"])
+        .output()
+        .expect("inspect imported histories");
+    let inspect_stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        inspect_stdout.contains("Command events: 2"),
+        "{inspect_stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- add `soon events import-zsh --preview` and an idempotent import path for plain and extended Zsh history
- preserve only source metadata: extended timestamp/duration stay known while cwd, exit status, and plain-history time remain unknown
- derive stable event IDs, deduplicate overlapping rotated files, and retain safe command transitions without crossing filtered or malformed entries
- report aggregate importable, sensitive, malformed, duplicate, existing, and imported counts without printing commands
- allow imported unknown-result transitions to serve as a lower-priority cold-start fallback behind live result-matched evidence
- document default and explicit rotated-file workflows

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (34 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `uvx pre-commit run --all-files`
- `cargo run --locked -- events import-zsh --help`
- `git diff --check`

Closes #10
Refs #4
Refs #11