### PR TITLE
feat: add chronological replay metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ soon which
 
 # Show the most common executables in local history
 soon stats
+
+# Measure the current policy against past local transitions
+soon replay
 ```
 
 Override shell detection when needed:
@@ -112,7 +115,7 @@ The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and t
 |---|---|
 | On-demand command plus opt-in Zsh loop | Coherent beta install and clean-session smoke test |
 | Manual, successful-command Next-step, and failed-command Repair triggers | Clean-session lifecycle regression coverage |
-| Retained command and suggestion events with feedback | Local replay quality and latency metrics |
+| Retained events plus chronological quality and latency replay | Release-gate fixture with a 20 ms Zsh p95 budget |
 | Sensitive-command filters plus idempotent Zsh history import | A documented v0.4 privacy and release audit |
 
 The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). Work is tracked in the public [Personal Terminal Agent Project](https://github.com/users/HsiangNianian/projects/7).
@@ -125,17 +128,17 @@ The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/
 4. Accumulate repeated transition evidence and weight newer evidence more heavily.
 5. Print the highest-ranked full command without presenting the heuristic as calibrated confidence.
 
-This baseline is deliberately simple. A more complex ranker must beat it on the local replay metrics planned in [#11](https://github.com/HsiangNianian/soon/issues/11).
+This baseline is deliberately simple. A more complex ranker must beat it under `soon replay` before it replaces the deterministic hot path.
 
 ## Agent roadmap
 
-The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) combines safe command lifecycle events, explicit `soon`, Next-step after success, Repair after failure, and a private history-import path. The remaining gate is measured local replay plus a coherent beta release.
+The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) combines safe command lifecycle events, explicit `soon`, Next-step after success, Repair after failure, a private history-import path, and measured local replay. The remaining gate is a coherent beta release.
 
 The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) then measures a contextual probabilistic ranker in [#16](https://github.com/HsiangNianian/soon/issues/16) before adding opt-in local-model and OpenAI-compatible candidate sources in [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
 
 ## Privacy
 
-`soon`, `soon now`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
+`soon`, `soon now`, `soon replay`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
 
 The current source rejects likely inline API keys, tokens, authorization headers, password flags, private-key material, and known credential prefixes before storing a command or suggestion. It applies the same filter again before ranking or rendering shell history, old event data, legacy learn data, provider context, and model output. Rejections report a category, not the command text.
 
@@ -193,6 +196,18 @@ soon events import-zsh \
 
 Plain command-per-line history and Zsh extended history (`: <epoch>:<duration>;<command>`) are supported. Extended timestamps and durations are preserved; unavailable cwd, exit status, and plain-history timestamps remain unknown. Preview and import summaries report importable, sensitive, malformed, duplicate, and already-imported counts without printing command text. Stable event IDs make repeated imports idempotent, including identical rotated files.
 
+Measure the deterministic policy against that local event memory:
+
+```bash
+soon replay
+```
+
+Replay follows JSONL append order rather than event timestamps. For each linked command transition it predicts first, scores the result, and only then exposes that transition to later samples, so future observations cannot leak into training. Unknown exit status is classified as `manual`; exit status zero is `next-step`; any other status is `repair`.
+
+`Samples` counts eligible linked transitions. Coverage is predictions divided by samples, and top-1 match is exact command matches divided by all samples. Overall and per-trigger rows include p50/p95 prediction latency. Candidate-source rows compare deterministic history with contextual policy, local model, or remote-provider suggestions when those sources have recorded a `shown` event before the actual next command. Model attempts aligned to a later command also report timeout, invalid-output, and deterministic-fallback rates.
+
+The report is aggregate-only: it prints no command text and performs no upload. The deterministic CI fixture has a Zsh hot-path p95 budget of **20 ms**; `soon replay` prints `PASS` or `FAIL` against that budget on the current local event set.
+
 Config lives at `~/.config/soon/config.toml`:
 
 ```bash
@@ -212,6 +227,7 @@ soon stats              Show the most-used executables
 soon which              Show shell and history diagnostics
 soon config             View or change local configuration
 soon events             Inspect, clear, or import local agent events
+soon replay             Measure local prediction quality and latency
 soon learn              Use the experimental learning tools
 soon update             Check the configured release channel
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,8 @@ pub enum Commands {
         #[command(subcommand)]
         action: EventsAction,
     },
+    /// Measure local prediction quality with chronological event replay
+    Replay,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -119,6 +121,9 @@ pub enum EventsAction {
         outcome: String,
         #[arg(long)]
         latency_ms: f64,
+        /// Outcome of an optional model attempt (used by prediction providers)
+        #[arg(long)]
+        model_outcome: Option<String>,
     },
 }
 

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,6 +1,8 @@
 use crate::cli::EventsAction;
 use crate::config::AppConfig;
-use crate::events::{self, CommandEvent, SuggestionEvent, SuggestionOutcome, SCHEMA_VERSION};
+use crate::events::{
+    self, CommandEvent, ModelOutcome, SuggestionEvent, SuggestionOutcome, SCHEMA_VERSION,
+};
 use crate::history_import;
 use crate::shell::{self, ShellKind};
 
@@ -40,11 +42,20 @@ pub fn run(action: EventsAction, config: &AppConfig) {
             command,
             outcome,
             latency_ms,
+            model_outcome,
         } => {
             let outcome = SuggestionOutcome::parse(&outcome).unwrap_or_else(|error| {
                 eprintln!("{error}");
                 std::process::exit(2);
             });
+            let model_outcome = model_outcome
+                .as_deref()
+                .map(ModelOutcome::parse)
+                .transpose()
+                .unwrap_or_else(|error| {
+                    eprintln!("{error}");
+                    std::process::exit(2);
+                });
             record_suggestion(
                 SuggestionEvent {
                     schema_version: SCHEMA_VERSION,
@@ -55,6 +66,7 @@ pub fn run(action: EventsAction, config: &AppConfig) {
                     command,
                     outcome,
                     latency_ms,
+                    model_outcome,
                 },
                 config,
             );

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod events;
 pub mod init;
 pub mod learn;
 pub mod now;
+pub mod replay;
 pub mod stats;
 pub mod update;
 pub mod which;

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -1,0 +1,86 @@
+use crate::config::AppConfig;
+use crate::replay::{self, Metrics, Trigger};
+
+pub fn run(config: &AppConfig) {
+    let report = replay::run(config);
+
+    println!("Local chronological replay");
+    print_summary(&report.overall);
+    println!();
+    println!("By trigger:");
+    for trigger in Trigger::ALL {
+        let metrics = report.trigger(trigger);
+        println!(
+            "  {:<9} samples={} coverage={:.1}% top-1={:.1}% p50={:.3}ms p95={:.3}ms",
+            trigger.label(),
+            metrics.samples,
+            metrics.coverage_percent(),
+            metrics.top1_percent(),
+            metrics.p50_ms(),
+            metrics.p95_ms()
+        );
+    }
+    println!();
+    println!("Candidate sources:");
+    for (source, metrics) in report.sources() {
+        println!(
+            "  {source:<21} samples={} coverage={:.1}% top-1={:.1}% p50={:.3}ms p95={:.3}ms",
+            metrics.samples,
+            metrics.coverage_percent(),
+            metrics.top1_percent(),
+            metrics.p50_ms(),
+            metrics.p95_ms()
+        );
+    }
+    println!();
+    println!("Model outcomes:");
+    println!("  Attempts: {}", report.model.attempts);
+    println!(
+        "  Timeout: {:.1}% ({}/{})",
+        report.model.timeout_percent(),
+        report.model.timeouts,
+        report.model.attempts
+    );
+    println!(
+        "  Invalid output: {:.1}% ({}/{})",
+        report.model.invalid_output_percent(),
+        report.model.invalid_outputs,
+        report.model.attempts
+    );
+    println!(
+        "  Deterministic fallback: {:.1}% ({}/{})",
+        report.model.deterministic_fallback_percent(),
+        report.model.deterministic_fallbacks,
+        report.model.attempts
+    );
+    println!();
+    println!(
+        "Zsh p95 budget: {} ({:.3} ms <= {:.0} ms)",
+        if report.overall.p95_ms() <= replay::ZSH_P95_BUDGET_MS {
+            "PASS"
+        } else {
+            "FAIL"
+        },
+        report.overall.p95_ms(),
+        replay::ZSH_P95_BUDGET_MS
+    );
+    println!("Privacy: aggregate metrics only; no command text printed or uploaded.");
+}
+
+fn print_summary(metrics: &Metrics) {
+    println!("Samples: {}", metrics.samples);
+    println!(
+        "Coverage: {:.1}% ({}/{})",
+        metrics.coverage_percent(),
+        metrics.covered,
+        metrics.samples
+    );
+    println!(
+        "Top-1 match: {:.1}% ({}/{})",
+        metrics.top1_percent(),
+        metrics.top1_matches,
+        metrics.samples
+    );
+    println!("p50 latency: {:.3} ms", metrics.p50_ms());
+    println!("p95 latency: {:.3} ms", metrics.p95_ms());
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -25,7 +25,7 @@ pub struct CommandEvent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-enum StoredEvent {
+pub(crate) enum StoredEvent {
     Command(CommandEvent),
     Suggestion(SuggestionEvent),
 }
@@ -40,6 +40,29 @@ pub struct SuggestionEvent {
     pub command: String,
     pub outcome: SuggestionOutcome,
     pub latency_ms: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_outcome: Option<ModelOutcome>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModelOutcome {
+    Success,
+    Timeout,
+    InvalidOutput,
+    DeterministicFallback,
+}
+
+impl ModelOutcome {
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "success" => Ok(Self::Success),
+            "timeout" => Ok(Self::Timeout),
+            "invalid-output" => Ok(Self::InvalidOutput),
+            "deterministic-fallback" => Ok(Self::DeterministicFallback),
+            _ => Err(format!("Unknown model outcome: {value}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -293,6 +316,10 @@ fn load_stored_events(path: &std::path::Path) -> Vec<StoredEvent> {
         .flat_map(|reader| reader.lines().map_while(Result::ok))
         .filter_map(|line| serde_json::from_str::<StoredEvent>(&line).ok())
         .collect()
+}
+
+pub(crate) fn replay_events() -> Vec<StoredEvent> {
+    load_stored_events(&event_store_path())
 }
 
 fn append_many(path: &std::path::Path, events: &[StoredEvent]) -> Result<(), String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod history_import;
 mod learn;
 mod predict;
 mod privacy;
+mod replay;
 mod shell;
 
 use clap::Parser;
@@ -34,6 +35,7 @@ fn main() {
         Some(Commands::Init { shell }) => commands::init::run(shell),
         Some(Commands::Config { action }) => commands::config::run(action),
         Some(Commands::Events { action }) => commands::events::run(action, &config),
+        Some(Commands::Replay) => commands::replay::run(&config),
         Some(Commands::Update) => commands::update::run(&config),
         Some(Commands::Learn { action }) => {
             // Learn works even with unknown shell (ingest-all detects automatically)

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,0 +1,344 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
+use crate::config::AppConfig;
+use crate::events::{
+    self, CommandEvent, ModelOutcome, StoredEvent, SuggestionEvent, SuggestionOutcome,
+};
+use crate::predict::{is_ignored_command, main_cmd};
+use crate::privacy;
+
+pub const ZSH_P95_BUDGET_MS: f64 = 20.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Trigger {
+    Manual,
+    NextStep,
+    Repair,
+}
+
+impl Trigger {
+    pub const ALL: [Self; 3] = [Self::Manual, Self::NextStep, Self::Repair];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::NextStep => "next-step",
+            Self::Repair => "repair",
+        }
+    }
+
+    fn from_exit_code(exit_code: Option<i32>) -> Self {
+        match exit_code {
+            None => Self::Manual,
+            Some(0) => Self::NextStep,
+            Some(_) => Self::Repair,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Metrics {
+    pub samples: usize,
+    pub covered: usize,
+    pub top1_matches: usize,
+    latencies_ms: Vec<f64>,
+}
+
+impl Metrics {
+    pub fn coverage_percent(&self) -> f64 {
+        percent(self.covered, self.samples)
+    }
+
+    pub fn top1_percent(&self) -> f64 {
+        percent(self.top1_matches, self.samples)
+    }
+
+    pub fn p50_ms(&self) -> f64 {
+        percentile(&self.latencies_ms, 0.50)
+    }
+
+    pub fn p95_ms(&self) -> f64 {
+        percentile(&self.latencies_ms, 0.95)
+    }
+
+    fn record(&mut self, prediction: Option<&str>, actual: &str, latency_ms: f64) {
+        self.samples += 1;
+        self.covered += usize::from(prediction.is_some());
+        self.top1_matches += usize::from(prediction == Some(actual));
+        self.latencies_ms.push(latency_ms);
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ModelMetrics {
+    pub attempts: usize,
+    pub timeouts: usize,
+    pub invalid_outputs: usize,
+    pub deterministic_fallbacks: usize,
+}
+
+impl ModelMetrics {
+    pub fn timeout_percent(&self) -> f64 {
+        percent(self.timeouts, self.attempts)
+    }
+
+    pub fn invalid_output_percent(&self) -> f64 {
+        percent(self.invalid_outputs, self.attempts)
+    }
+
+    pub fn deterministic_fallback_percent(&self) -> f64 {
+        percent(self.deterministic_fallbacks, self.attempts)
+    }
+
+    fn record(&mut self, outcome: ModelOutcome) {
+        self.attempts += 1;
+        match outcome {
+            ModelOutcome::Success => {}
+            ModelOutcome::Timeout => self.timeouts += 1,
+            ModelOutcome::InvalidOutput => self.invalid_outputs += 1,
+            ModelOutcome::DeterministicFallback => self.deterministic_fallbacks += 1,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ReplayReport {
+    pub overall: Metrics,
+    by_trigger: HashMap<Trigger, Metrics>,
+    by_source: HashMap<String, Metrics>,
+    pub model: ModelMetrics,
+}
+
+impl ReplayReport {
+    pub fn trigger(&self, trigger: Trigger) -> Metrics {
+        self.by_trigger.get(&trigger).cloned().unwrap_or_default()
+    }
+
+    pub fn sources(&self) -> Vec<(&str, Metrics)> {
+        let mut sources: Vec<_> = self
+            .by_source
+            .iter()
+            .map(|(source, metrics)| (source.as_str(), metrics.clone()))
+            .collect();
+        sources.sort_by_key(|(source, _)| *source);
+        sources
+    }
+}
+
+#[derive(Debug)]
+struct Transition<'a> {
+    previous: &'a CommandEvent,
+    next: &'a CommandEvent,
+    index: usize,
+}
+
+#[derive(Debug, Default)]
+struct CandidateScore {
+    result_matches: usize,
+    evidence: usize,
+    directory_matches: usize,
+    latest_index: usize,
+}
+
+#[derive(Debug)]
+struct RecordedSuggestion<'a> {
+    source: &'static str,
+    event: &'a SuggestionEvent,
+}
+
+pub fn run(config: &AppConfig) -> ReplayReport {
+    let stored_events = events::replay_events();
+    let mut seen = HashMap::<&str, &CommandEvent>::new();
+    let mut transitions = Vec::<Transition<'_>>::new();
+    let mut pending = HashMap::<&str, Vec<RecordedSuggestion<'_>>>::new();
+    let mut pending_manual = Vec::<RecordedSuggestion<'_>>::new();
+    let mut report = ReplayReport::default();
+
+    for stored_event in &stored_events {
+        match stored_event {
+            StoredEvent::Command(command) if is_safe(command, config) => {
+                if is_candidate(&command.command, config) {
+                    score_recorded(&mut report, std::mem::take(&mut pending_manual), command);
+                } else {
+                    pending_manual.clear();
+                }
+
+                if let Some(previous_id) = command.previous_event_id.as_deref() {
+                    if let Some(previous) = seen.get(previous_id).copied() {
+                        if is_candidate(&command.command, config) {
+                            let started = Instant::now();
+                            let prediction = predict(previous, &transitions, config);
+                            let latency_ms = started.elapsed().as_secs_f64() * 1_000.0;
+                            let trigger = Trigger::from_exit_code(previous.exit_code);
+
+                            report.overall.record(
+                                prediction.as_deref(),
+                                command.command.trim(),
+                                latency_ms,
+                            );
+                            report.by_trigger.entry(trigger).or_default().record(
+                                prediction.as_deref(),
+                                command.command.trim(),
+                                latency_ms,
+                            );
+                            report
+                                .by_source
+                                .entry("deterministic-history".to_string())
+                                .or_default()
+                                .record(prediction.as_deref(), command.command.trim(), latency_ms);
+                        }
+
+                        if let Some(suggestions) = pending.remove(previous.id.as_str()) {
+                            if is_candidate(&command.command, config) {
+                                score_recorded(&mut report, suggestions, command);
+                            }
+                        }
+                        transitions.push(Transition {
+                            previous,
+                            next: command,
+                            index: transitions.len(),
+                        });
+                    }
+                }
+                seen.insert(command.id.as_str(), command);
+            }
+            StoredEvent::Suggestion(suggestion)
+                if suggestion.outcome == SuggestionOutcome::Shown
+                    && is_safe_suggestion(suggestion, config) =>
+            {
+                let recorded = RecordedSuggestion {
+                    source: canonical_source(&suggestion.candidate_source),
+                    event: suggestion,
+                };
+                if let Some(command_event_id) = suggestion.command_event_id.as_deref() {
+                    pending.entry(command_event_id).or_default().push(recorded);
+                } else {
+                    pending_manual.push(recorded);
+                }
+            }
+            StoredEvent::Command(_) | StoredEvent::Suggestion(_) => {}
+        }
+    }
+
+    report
+}
+
+fn score_recorded(
+    report: &mut ReplayReport,
+    suggestions: Vec<RecordedSuggestion<'_>>,
+    actual: &CommandEvent,
+) {
+    for suggestion in suggestions {
+        report
+            .by_source
+            .entry(suggestion.source.to_string())
+            .or_default()
+            .record(
+                Some(suggestion.event.command.trim()),
+                actual.command.trim(),
+                suggestion.event.latency_ms,
+            );
+        if let Some(outcome) = suggestion.event.model_outcome {
+            report.model.record(outcome);
+        }
+    }
+}
+
+fn is_safe(event: &CommandEvent, config: &AppConfig) -> bool {
+    privacy::rejection_reason(&event.command, config).is_none()
+        && !event.command.chars().any(char::is_control)
+}
+
+fn is_safe_suggestion(event: &SuggestionEvent, config: &AppConfig) -> bool {
+    privacy::rejection_reason(&event.command, config).is_none()
+        && !event.command.chars().any(char::is_control)
+        && is_candidate(&event.command, config)
+}
+
+fn is_candidate(command: &str, config: &AppConfig) -> bool {
+    !is_ignored_command(main_cmd(command), config)
+}
+
+fn canonical_source(source: &str) -> &'static str {
+    match source
+        .trim()
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .as_str()
+    {
+        "history" | "deterministic-history" => "deterministic-history",
+        "context" | "contextual-policy" => "contextual-policy",
+        "local-model" => "local-model",
+        "remote" | "remote-provider" => "remote-provider",
+        "deterministic-fallback" => "deterministic-fallback",
+        _ => "other",
+    }
+}
+
+fn predict(
+    current: &CommandEvent,
+    transitions: &[Transition<'_>],
+    config: &AppConfig,
+) -> Option<String> {
+    let wanted_success = current.exit_code.map(|code| code == 0);
+    let mut candidates = HashMap::<&str, CandidateScore>::new();
+
+    for transition in transitions {
+        if transition.previous.command.trim() != current.command.trim()
+            || matches!(
+                (
+                    transition.previous.exit_code.map(|code| code == 0),
+                    wanted_success
+                ),
+                (Some(observed), Some(wanted)) if observed != wanted
+            )
+            || privacy::rejection_reason(&transition.next.command, config).is_some()
+            || is_ignored_command(main_cmd(&transition.next.command), config)
+        {
+            continue;
+        }
+
+        let score = candidates
+            .entry(transition.next.command.trim())
+            .or_default();
+        score.result_matches += usize::from(transition.previous.exit_code.is_some());
+        score.evidence += 1;
+        score.directory_matches +=
+            usize::from(current.cwd.is_some() && transition.previous.cwd == current.cwd);
+        score.latest_index = transition.index;
+    }
+
+    let mut ranked: Vec<_> = candidates.into_iter().collect();
+    ranked.sort_by(|(command_a, score_a), (command_b, score_b)| {
+        score_b
+            .result_matches
+            .cmp(&score_a.result_matches)
+            .then_with(|| score_b.directory_matches.cmp(&score_a.directory_matches))
+            .then_with(|| score_b.evidence.cmp(&score_a.evidence))
+            .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
+            .then_with(|| command_a.cmp(command_b))
+    });
+    ranked
+        .into_iter()
+        .next()
+        .map(|(command, _)| command.to_string())
+}
+
+fn percent(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 * 100.0 / denominator as f64
+    }
+}
+
+fn percentile(values: &[f64], percentile: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let rank = (percentile * sorted.len() as f64).ceil() as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}

--- a/tests/replay_cli.rs
+++ b/tests/replay_cli.rs
@@ -1,0 +1,286 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_HOME: AtomicU64 = AtomicU64::new(0);
+
+fn isolated_home() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let sequence = NEXT_HOME.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "soon-replay-test-{}-{nonce}-{sequence}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&path).expect("create isolated home");
+    path
+}
+
+fn soon(home: &PathBuf) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_soon"));
+    command
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"));
+    command
+}
+
+fn record_command(
+    home: &PathBuf,
+    id: &str,
+    text: &str,
+    exit_code: &str,
+    previous_id: Option<&str>,
+) {
+    let mut args = vec![
+        "events",
+        "record-command",
+        "--id",
+        id,
+        "--command",
+        text,
+        "--cwd",
+        "/tmp/soon-project",
+        "--started-at-ms",
+        "1000",
+        "--duration-ms",
+        "25",
+        "--exit-code",
+        exit_code,
+        "--shell",
+        "zsh",
+    ];
+    if let Some(previous_id) = previous_id {
+        args.extend(["--previous-id", previous_id]);
+    }
+
+    let output = soon(home)
+        .args(args)
+        .output()
+        .expect("record command event");
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn record_suggestion(
+    home: &PathBuf,
+    id: &str,
+    command_event_id: &str,
+    source: &str,
+    text: &str,
+    model_outcome: Option<&str>,
+) {
+    let mut args = vec![
+        "events",
+        "record-suggestion",
+        "--id",
+        id,
+        "--command-event-id",
+        command_event_id,
+        "--trigger",
+        "repair",
+        "--candidate-source",
+        source,
+        "--command",
+        text,
+        "--outcome",
+        "shown",
+        "--latency-ms",
+        "7.5",
+    ];
+    if let Some(model_outcome) = model_outcome {
+        args.extend(["--model-outcome", model_outcome]);
+    }
+
+    let output = soon(home)
+        .args(args)
+        .output()
+        .expect("record suggestion event");
+    assert!(
+        output.status.success(),
+        "record suggestion failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn chronological_replay_never_learns_from_the_sample_being_scored() {
+    let home = isolated_home();
+    let commands = [
+        ("command-1", "git status", None),
+        ("command-2", "cargo test", Some("command-1")),
+        ("command-3", "cargo fmt", Some("command-2")),
+        ("command-4", "git status", Some("command-3")),
+        ("command-5", "cargo test", Some("command-4")),
+    ];
+    for (id, text, previous_id) in commands {
+        record_command(&home, id, text, "0", previous_id);
+    }
+
+    let replay = soon(&home).arg("replay").output().expect("replay events");
+    let stdout = String::from_utf8(replay.stdout).expect("UTF-8 replay output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        replay.status.success(),
+        "replay failed: {}",
+        String::from_utf8_lossy(&replay.stderr)
+    );
+    assert!(stdout.contains("Samples: 4"), "{stdout}");
+    assert!(stdout.contains("Coverage: 25.0% (1/4)"), "{stdout}");
+    assert!(stdout.contains("Top-1 match: 25.0% (1/4)"), "{stdout}");
+    assert!(stdout.contains("p50 latency:"), "{stdout}");
+    assert!(stdout.contains("p95 latency:"), "{stdout}");
+    assert!(stdout.contains("Zsh p95 budget: PASS"), "{stdout}");
+    assert!(stdout.contains("next-step"), "{stdout}");
+    assert!(stdout.contains("history"), "{stdout}");
+    for (_, text, _) in commands {
+        assert!(
+            !stdout.contains(text),
+            "replay leaked command text: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn replay_breaks_metrics_down_by_manual_next_step_and_repair_trigger() {
+    let home = isolated_home();
+    std::fs::write(home.join("manual-history"), "git status\ncargo test\n")
+        .expect("write import fixture");
+    let import = soon(&home)
+        .args([
+            "events",
+            "import-zsh",
+            "--path",
+            home.join("manual-history").to_str().expect("UTF-8 path"),
+        ])
+        .output()
+        .expect("import Zsh history");
+    assert!(import.status.success(), "import failed");
+
+    record_command(&home, "failed", "cargo build", "1", None);
+    record_command(
+        &home,
+        "repair",
+        "cargo build --verbose",
+        "0",
+        Some("failed"),
+    );
+    record_command(&home, "next", "git diff --stat", "0", Some("repair"));
+
+    let replay = soon(&home).arg("replay").output().expect("replay events");
+    let stdout = String::from_utf8(replay.stdout).expect("UTF-8 replay output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(replay.status.success(), "replay failed");
+    assert!(stdout.contains("manual    samples=1"), "{stdout}");
+    assert!(stdout.contains("next-step samples=1"), "{stdout}");
+    assert!(stdout.contains("repair    samples=1"), "{stdout}");
+}
+
+#[test]
+fn recorded_sources_and_model_failures_are_scored_only_after_they_occur() {
+    let home = isolated_home();
+    let actual = "cargo test -- --nocapture";
+    record_command(&home, "failed", "cargo test", "1", None);
+    record_suggestion(
+        &home,
+        "local-success",
+        "failed",
+        "local-model",
+        actual,
+        Some("success"),
+    );
+    record_suggestion(
+        &home,
+        "remote-timeout",
+        "failed",
+        "remote-provider",
+        "cargo check",
+        Some("timeout"),
+    );
+    record_suggestion(
+        &home,
+        "local-invalid",
+        "failed",
+        "local-model",
+        "cargo clippy",
+        Some("invalid-output"),
+    );
+    record_suggestion(
+        &home,
+        "remote-fallback",
+        "failed",
+        "remote-provider",
+        actual,
+        Some("deterministic-fallback"),
+    );
+    record_suggestion(
+        &home,
+        "contextual",
+        "failed",
+        "contextual-policy",
+        actual,
+        None,
+    );
+    record_command(&home, "fixed", actual, "0", Some("failed"));
+    record_suggestion(
+        &home,
+        "too-late",
+        "failed",
+        "late-unknown-source",
+        actual,
+        None,
+    );
+
+    let replay = soon(&home).arg("replay").output().expect("replay events");
+    let stdout = String::from_utf8(replay.stdout).expect("UTF-8 replay output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(replay.status.success(), "replay failed");
+    let local_model = stdout
+        .lines()
+        .find(|line| line.contains("local-model"))
+        .expect("local model row");
+    assert!(
+        local_model.contains("samples=2 coverage=100.0% top-1=50.0%"),
+        "{stdout}"
+    );
+    let remote_provider = stdout
+        .lines()
+        .find(|line| line.contains("remote-provider"))
+        .expect("remote provider row");
+    assert!(
+        remote_provider.contains("samples=2 coverage=100.0% top-1=50.0%"),
+        "{stdout}"
+    );
+    let contextual = stdout
+        .lines()
+        .find(|line| line.contains("contextual-policy"))
+        .expect("contextual policy row");
+    assert!(
+        contextual.contains("samples=1 coverage=100.0% top-1=100.0%"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.lines().any(|line| line.starts_with("  other")),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Attempts: 4"), "{stdout}");
+    assert!(stdout.contains("Timeout: 25.0% (1/4)"), "{stdout}");
+    assert!(stdout.contains("Invalid output: 25.0% (1/4)"), "{stdout}");
+    assert!(
+        stdout.contains("Deterministic fallback: 25.0% (1/4)"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains(actual),
+        "replay leaked command text: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #11

## Summary
- add local chronological replay without future-observation leakage
- report aggregate, trigger, candidate-source, and model failure metrics
- keep output command-free and document the 20 ms Zsh p95 budget

## Verification
- cargo fmt --all -- --check
- cargo check --locked
- cargo test --locked
- zsh tests/zsh_integration.zsh target/debug/soon
- cargo clippy --locked --all-targets -- -D warnings
- cargo run --locked -- --version