### PR TITLE
feat: export privacy-safe adoption reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ soon stats
 
 # Measure the current policy against past local transitions
 soon replay
+
+# Export aggregate adoption metrics that are safe to share
+soon report
+soon report --json
 ```
 
 Override shell detection when needed:
@@ -143,7 +147,7 @@ The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milest
 
 ## Privacy
 
-`soon`, `soon now`, `soon replay`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
+`soon`, `soon now`, `soon replay`, `soon report`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
 
 The current source rejects likely inline API keys, tokens, authorization headers, password flags, private-key material, and known credential prefixes before storing a command or suggestion. It applies the same filter again before ranking or rendering shell history, old event data, legacy learn data, provider context, and model output. Rejections report a category, not the command text.
 
@@ -213,6 +217,30 @@ Replay follows JSONL append order rather than event timestamps. For each linked 
 
 The report is aggregate-only: it prints no command text and performs no upload. The deterministic CI fixture has a Zsh hot-path p95 budget of **20 ms**; `soon replay` prints `PASS` or `FAIL` against that budget on the current local event set.
 
+Export the smaller adoption report when sharing beta feedback:
+
+```bash
+soon report
+soon report --json
+```
+
+This is an explicit, offline read of the same local event store. Both forms contain aggregate counters and latency distributions only—never raw commands, arguments, paths, hostnames, usernames, event IDs, timestamps, or database rows. The human form is designed for an issue or discussion; `--json` is suitable for scripts and uses schema version `1`:
+
+| JSON field | Meaning |
+|---|---|
+| `schema_version` | Report schema version; currently `1` |
+| `samples.eligible_transitions` | Linked command transitions eligible for chronological replay |
+| `samples.predictions` | Eligible transitions for which the deterministic replay produced a prediction |
+| `samples.prediction_coverage_percent` | `predictions / eligible_transitions * 100` |
+| `suggestions.shown` | Retained suggestion events with the `shown` outcome |
+| `suggestions.accepted` | Retained suggestion events with the `accepted` outcome |
+| `suggestions.acceptance_percent` | `accepted / shown * 100` |
+| `suggestions.executed` | Retained suggestion events with the `executed` outcome |
+| `suggestions.execution_percent` | `executed / shown * 100` |
+| `latency_ms.p50`, `latency_ms.p95` | Replay prediction latency percentiles in milliseconds |
+
+A percentage is `null` when its denominator is zero, and both latency values are `null` when there are no eligible transitions. Human output prints `n/a` for the same cases. This keeps empty and partially retained event stores valid without presenting missing observations as zero-latency measurements.
+
 Config lives at `~/.config/soon/config.toml`:
 
 ```bash
@@ -234,6 +262,7 @@ soon which              Show shell and history diagnostics
 soon config             View or change local configuration
 soon events             Inspect, clear, or import local agent events
 soon replay             Measure local prediction quality and latency
+soon report             Export privacy-safe aggregate adoption metrics
 soon learn              Use the experimental learning tools
 soon update             Check the configured release channel
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,6 +63,12 @@ pub enum Commands {
     },
     /// Measure local prediction quality with chronological event replay
     Replay,
+    /// Print a privacy-safe local adoption report
+    Report {
+        /// Emit the stable machine-readable schema
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod init;
 pub mod learn;
 pub mod now;
 pub mod replay;
+pub mod report;
 pub mod stats;
 pub mod update;
 pub mod which;

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -1,0 +1,55 @@
+use crate::config::AppConfig;
+use crate::report;
+
+pub fn run(config: &AppConfig, json: bool) {
+    let report = report::build(config);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).expect("serialize aggregate adoption report")
+        );
+        return;
+    }
+
+    println!("Privacy-safe adoption report");
+    println!("Samples: {}", report.samples.eligible_transitions);
+    if let Some(coverage) = report.samples.prediction_coverage_percent {
+        println!(
+            "Prediction coverage: {coverage:.1}% ({}/{})",
+            report.samples.predictions, report.samples.eligible_transitions
+        );
+    } else {
+        println!("Prediction coverage: n/a (0/0)");
+    }
+    println!("Suggestions shown: {}", report.suggestions.shown);
+    print_outcome(
+        "Accepted",
+        report.suggestions.accepted,
+        report.suggestions.acceptance_percent,
+    );
+    print_outcome(
+        "Executed",
+        report.suggestions.executed,
+        report.suggestions.execution_percent,
+    );
+    print_latency("p50", report.latency_ms.p50);
+    print_latency("p95", report.latency_ms.p95);
+    println!("Privacy: aggregate metrics only; no command text or paths included.");
+}
+
+fn print_outcome(label: &str, count: usize, percent: Option<f64>) {
+    if let Some(percent) = percent {
+        println!("{label}: {count} ({percent:.1}% of shown)");
+    } else {
+        println!("{label}: {count} (n/a; no shown suggestions)");
+    }
+}
+
+fn print_latency(label: &str, latency_ms: Option<f64>) {
+    if let Some(latency_ms) = latency_ms {
+        println!("{label} latency: {latency_ms:.3} ms");
+    } else {
+        println!("{label} latency: n/a");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod learn;
 mod predict;
 mod privacy;
 mod replay;
+mod report;
 mod shell;
 
 use clap::Parser;
@@ -36,6 +37,7 @@ fn main() {
         Some(Commands::Config { action }) => commands::config::run(action),
         Some(Commands::Events { action }) => commands::events::run(action, &config),
         Some(Commands::Replay) => commands::replay::run(&config),
+        Some(Commands::Report { json }) => commands::report::run(&config, json),
         Some(Commands::Update) => commands::update::run(&config),
         Some(Commands::Learn { action }) => {
             // Learn works even with unknown shell (ingest-all detects automatically)

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,68 @@
+use crate::config::AppConfig;
+use crate::{events, replay};
+use serde::Serialize;
+
+pub const SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct AdoptionReport {
+    pub schema_version: u8,
+    pub samples: SampleMetrics,
+    pub suggestions: SuggestionMetrics,
+    pub latency_ms: LatencyMetrics,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct SampleMetrics {
+    pub eligible_transitions: usize,
+    pub predictions: usize,
+    pub prediction_coverage_percent: Option<f64>,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct SuggestionMetrics {
+    pub shown: usize,
+    pub accepted: usize,
+    pub acceptance_percent: Option<f64>,
+    pub executed: usize,
+    pub execution_percent: Option<f64>,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct LatencyMetrics {
+    pub p50: Option<f64>,
+    pub p95: Option<f64>,
+}
+
+pub fn build(config: &AppConfig) -> AdoptionReport {
+    let replay = replay::run(config);
+    let events = events::inspect();
+
+    AdoptionReport {
+        schema_version: SCHEMA_VERSION,
+        samples: SampleMetrics {
+            eligible_transitions: replay.overall.samples,
+            predictions: replay.overall.covered,
+            prediction_coverage_percent: percent(replay.overall.covered, replay.overall.samples),
+        },
+        suggestions: SuggestionMetrics {
+            shown: events.shown,
+            accepted: events.accepted,
+            acceptance_percent: percent(events.accepted, events.shown),
+            executed: events.executed,
+            execution_percent: percent(events.executed, events.shown),
+        },
+        latency_ms: LatencyMetrics {
+            p50: (replay.overall.samples > 0).then(|| replay.overall.p50_ms()),
+            p95: (replay.overall.samples > 0).then(|| replay.overall.p95_ms()),
+        },
+    }
+}
+
+fn percent(numerator: usize, denominator: usize) -> Option<f64> {
+    if denominator == 0 {
+        None
+    } else {
+        Some(numerator as f64 * 100.0 / denominator as f64)
+    }
+}

--- a/tests/report_cli.rs
+++ b/tests/report_cli.rs
@@ -1,0 +1,286 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_HOME: AtomicU64 = AtomicU64::new(0);
+
+fn isolated_home() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let sequence = NEXT_HOME.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "soon-report-test-{}-{nonce}-{sequence}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&path).expect("create isolated home");
+    path
+}
+
+fn soon(home: &PathBuf) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_soon"));
+    command
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"));
+    command
+}
+
+fn run(home: &PathBuf, args: &[&str]) -> Output {
+    let output = soon(home).args(args).output().expect("run soon");
+    assert!(
+        output.status.success(),
+        "soon {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn record_command(home: &PathBuf, id: &str, text: &str, previous_id: Option<&str>) {
+    let mut args = vec![
+        "events",
+        "record-command",
+        "--id",
+        id,
+        "--command",
+        text,
+        "--cwd",
+        "/private/work/soon",
+        "--started-at-ms",
+        "1000",
+        "--duration-ms",
+        "25",
+        "--exit-code",
+        "0",
+        "--shell",
+        "zsh",
+    ];
+    if let Some(previous_id) = previous_id {
+        args.extend(["--previous-id", previous_id]);
+    }
+    run(home, &args);
+}
+
+fn record_suggestion(home: &PathBuf, outcome: &str) {
+    run(
+        home,
+        &[
+            "events",
+            "record-suggestion",
+            "--id",
+            "suggestion-1",
+            "--command-event-id",
+            "command-4",
+            "--trigger",
+            "next-step",
+            "--candidate-source",
+            "deterministic-history",
+            "--command",
+            "cargo test --workspace",
+            "--outcome",
+            outcome,
+            "--latency-ms",
+            "7.5",
+        ],
+    );
+}
+
+fn populated_home() -> PathBuf {
+    let home = isolated_home();
+    for (id, text, previous_id) in [
+        ("command-1", "git status", None),
+        ("command-2", "cargo test", Some("command-1")),
+        ("command-3", "cargo fmt", Some("command-2")),
+        ("command-4", "git status", Some("command-3")),
+        ("command-5", "cargo test", Some("command-4")),
+    ] {
+        record_command(&home, id, text, previous_id);
+    }
+    for outcome in ["shown", "accepted", "executed"] {
+        record_suggestion(&home, outcome);
+    }
+    home
+}
+
+#[test]
+fn human_report_combines_replay_quality_with_adoption_outcomes() {
+    let home = populated_home();
+
+    let report = run(&home, &["report"]);
+    let stdout = String::from_utf8(report.stdout).expect("UTF-8 report output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(stdout.contains("Privacy-safe adoption report"), "{stdout}");
+    assert!(stdout.contains("Samples: 4"), "{stdout}");
+    assert!(
+        stdout.contains("Prediction coverage: 25.0% (1/4)"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Suggestions shown: 1"), "{stdout}");
+    assert!(stdout.contains("Accepted: 1 (100.0% of shown)"), "{stdout}");
+    assert!(stdout.contains("Executed: 1 (100.0% of shown)"), "{stdout}");
+    assert!(stdout.contains("p50 latency:"), "{stdout}");
+    assert!(stdout.contains("p95 latency:"), "{stdout}");
+}
+
+#[test]
+fn json_report_has_a_versioned_aggregate_only_schema() {
+    let home = populated_home();
+
+    let report = run(&home, &["report", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&report.stdout).expect("report is valid JSON");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert_eq!(json.as_object().expect("JSON object").len(), 4, "{json}");
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(
+        json["samples"],
+        serde_json::json!({
+            "eligible_transitions": 4,
+            "predictions": 1,
+            "prediction_coverage_percent": 25.0
+        })
+    );
+    assert_eq!(
+        json["suggestions"],
+        serde_json::json!({
+            "shown": 1,
+            "accepted": 1,
+            "acceptance_percent": 100.0,
+            "executed": 1,
+            "execution_percent": 100.0
+        })
+    );
+    assert_eq!(
+        json["latency_ms"]
+            .as_object()
+            .expect("latency object")
+            .len(),
+        2,
+        "{json}"
+    );
+    assert!(json["latency_ms"]["p50"].is_number(), "{json}");
+    assert!(json["latency_ms"]["p95"].is_number(), "{json}");
+}
+
+#[test]
+fn empty_store_reports_unavailable_rates_and_latency_without_failing() {
+    let home = isolated_home();
+
+    let human = run(&home, &["report"]);
+    let human = String::from_utf8(human.stdout).expect("UTF-8 report output");
+    let json = run(&home, &["report", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("empty report is valid JSON");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(human.contains("Samples: 0"), "{human}");
+    assert!(human.contains("Prediction coverage: n/a (0/0)"), "{human}");
+    assert!(
+        human.contains("Accepted: 0 (n/a; no shown suggestions)"),
+        "{human}"
+    );
+    assert!(
+        human.contains("Executed: 0 (n/a; no shown suggestions)"),
+        "{human}"
+    );
+    assert!(human.contains("p50 latency: n/a"), "{human}");
+    assert!(human.contains("p95 latency: n/a"), "{human}");
+    assert_eq!(json["samples"]["eligible_transitions"], 0);
+    assert_eq!(
+        json["samples"]["prediction_coverage_percent"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        json["suggestions"]["acceptance_percent"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        json["suggestions"]["execution_percent"],
+        serde_json::Value::Null
+    );
+    assert_eq!(json["latency_ms"]["p50"], serde_json::Value::Null);
+    assert_eq!(json["latency_ms"]["p95"], serde_json::Value::Null);
+}
+
+#[test]
+fn partially_populated_store_keeps_counts_but_not_undefined_rates() {
+    let home = isolated_home();
+    record_command(&home, "only-command", "git status", None);
+    record_suggestion(&home, "accepted");
+
+    let report = run(&home, &["report", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&report.stdout).expect("partial report is valid JSON");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert_eq!(json["samples"]["eligible_transitions"], 0);
+    assert_eq!(json["suggestions"]["shown"], 0);
+    assert_eq!(json["suggestions"]["accepted"], 1);
+    assert_eq!(
+        json["suggestions"]["acceptance_percent"],
+        serde_json::Value::Null
+    );
+    assert_eq!(json["latency_ms"]["p95"], serde_json::Value::Null);
+}
+
+#[test]
+fn reports_never_emit_sensitive_values_from_legacy_event_rows() {
+    let home = isolated_home();
+    let store = home.join(".local/share/soon/events.jsonl");
+    std::fs::create_dir_all(store.parent().expect("event directory"))
+        .expect("create event directory");
+    let sensitive_command = "export OPENAI_API_KEY=sk-private-report-marker";
+    let sensitive_path = "/Users/alice/private-client/report-marker";
+    let event_id = "private-event-id-report-marker";
+    let rows = [
+        serde_json::json!({
+            "kind": "command",
+            "schema_version": 1,
+            "id": event_id,
+            "command": sensitive_command,
+            "cwd": sensitive_path,
+            "started_at_ms": 1000,
+            "duration_ms": 25,
+            "exit_code": 0,
+            "shell": "zsh",
+            "previous_event_id": null
+        }),
+        serde_json::json!({
+            "kind": "suggestion",
+            "schema_version": 1,
+            "id": "private-suggestion-id-report-marker",
+            "command_event_id": event_id,
+            "trigger": "next-step",
+            "candidate_source": "deterministic-history",
+            "command": sensitive_command,
+            "outcome": "shown",
+            "latency_ms": 7.5
+        }),
+    ];
+    let encoded = rows
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&store, format!("{encoded}\n")).expect("write legacy event rows");
+
+    let human = run(&home, &["report"]);
+    let json = run(&home, &["report", "--json"]);
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8(human.stdout).expect("UTF-8 human report"),
+        String::from_utf8(json.stdout).expect("UTF-8 JSON report")
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+    for sensitive in [sensitive_command, sensitive_path, "alice", event_id] {
+        assert!(
+            !combined.contains(sensitive),
+            "report leaked {sensitive}: {combined}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add `soon report` and a stable `soon report --json` schema for aggregate adoption metrics
- combine chronological replay coverage and latency with shown, accepted, and executed suggestion outcomes
- represent unavailable rates and latency as `n/a` or `null` for empty and partially retained stores
- document the privacy contract, field definitions, and safe sharing workflow

## Impact

Early adopters can share useful product feedback without exposing commands, arguments, paths, hostnames, usernames, event IDs, timestamps, or database rows. The command is explicit, offline, and never uploads data.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (46 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `uvx pre-commit run --all-files`
- `cargo run --locked -- --help`
- `cargo run --locked -- report --help`
- `python3 tests/site_smoke.py`
- `python3 tests/site_smoke.py --online`

Closes #26
