### PR TITLE
release: publish the v0.4.1 adoption build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to soon are documented here.
 
+## 0.4.1 - 2026-07-27
+
+soon 0.4.1 is the adoption build for the local terminal-agent beta. It makes
+the product loop easier to evaluate and exposes privacy-safe measurements that
+distinguish offline replay performance from the latency users experience in
+the shell.
+
+### Added
+
+- Added a versioned landing page and deterministic terminal demo for the
+  Repair, Ctrl-F acceptance, and explicit execution loop
+  ([#28](https://github.com/HsiangNianian/soon/pull/28)).
+- Added explicit `soon report` and `soon report --json` commands for sharing
+  aggregate coverage, adoption, and latency metrics without command data
+  ([#29](https://github.com/HsiangNianian/soon/pull/29)).
+
+### Fixed
+
+- Split chronological replay latency from shell-observed suggestion latency,
+  and count each valid `shown` suggestion once instead of duplicating its
+  accepted, executed, or dismissed lifecycle rows
+  ([#30](https://github.com/HsiangNianian/soon/issues/30)).
+
+### Changed
+
+- Advanced the adoption report to schema version 2. Latency now contains
+  separate `replay` and `suggestion` distributions with explicit sample
+  counts and nullable p50/p95 values.
+- Clarified that a research issue may remain open when it explicitly depends
+  on the release artifact, avoiding a circular release gate.
+
+[Full diff](https://github.com/HsiangNianian/soon/compare/v0.4.0...v0.4.1)
+
 ## 0.4.0 - 2026-07-27
 
 soon 0.4.0 is the first local terminal-agent beta. Interactive integration is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "soon"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soon"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Local-first prediction for your next full shell command"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A local-first terminal agent that predicts, repairs, and suggests your next full
 [![CI](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml/badge.svg)](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-[Website](https://soon.hydroroll.team) · [v0.4 release](https://github.com/HsiangNianian/soon/releases/tag/v0.4.0) · [Roadmap](https://github.com/users/HsiangNianian/projects/7)
+[Website](https://soon.hydroroll.team) · [v0.4.1 adoption build](https://github.com/HsiangNianian/soon/releases/tag/v0.4.1) · [Roadmap](https://github.com/users/HsiangNianian/projects/7)
 
 </div>
 
-> **Beta status:** v0.4 ships the first opt-in Zsh ghost-suggestion loop. Interactive integration is supported on native Linux and macOS; other shells and packaged platforms remain experimental unless listed in the [release contract](RELEASING.md).
+> **Beta status:** v0.4.1 ships the first opt-in Zsh ghost-suggestion loop plus a privacy-safe adoption report. Interactive integration is supported on native Linux and macOS; other shells and packaged platforms remain experimental unless listed in the [release contract](RELEASING.md).
 
 <a href="https://soon.hydroroll.team">
   <img src="www/assets/soon-demo.svg" alt="An 18-second terminal demo: a failed Git command triggers a local Repair suggestion, Ctrl-F accepts it into the editable buffer, and the user decides when to execute it.">
@@ -23,7 +23,7 @@ A local-first terminal agent that predicts, repairs, and suggests your next full
 
 ## Try the beta
 
-Install the same v0.4 release through Cargo or PyPI:
+Install the same v0.4.1 release through Cargo or PyPI:
 
 ```bash
 cargo install soon
@@ -224,11 +224,11 @@ soon report
 soon report --json
 ```
 
-This is an explicit, offline read of the same local event store. Both forms contain aggregate counters and latency distributions only—never raw commands, arguments, paths, hostnames, usernames, event IDs, timestamps, or database rows. The human form is designed for an issue or discussion; `--json` is suitable for scripts and uses schema version `1`:
+This is an explicit, offline read of the same local event store. Both forms contain aggregate counters and latency distributions only—never raw commands, arguments, paths, hostnames, usernames, event IDs, timestamps, or database rows. The human form is designed for an issue or discussion; `--json` is suitable for scripts and uses schema version `2`:
 
 | JSON field | Meaning |
 |---|---|
-| `schema_version` | Report schema version; currently `1` |
+| `schema_version` | Report schema version; currently `2` |
 | `samples.eligible_transitions` | Linked command transitions eligible for chronological replay |
 | `samples.predictions` | Eligible transitions for which the deterministic replay produced a prediction |
 | `samples.prediction_coverage_percent` | `predictions / eligible_transitions * 100` |
@@ -237,9 +237,14 @@ This is an explicit, offline read of the same local event store. Both forms cont
 | `suggestions.acceptance_percent` | `accepted / shown * 100` |
 | `suggestions.executed` | Retained suggestion events with the `executed` outcome |
 | `suggestions.execution_percent` | `executed / shown * 100` |
-| `latency_ms.p50`, `latency_ms.p95` | Replay prediction latency percentiles in milliseconds |
+| `latency_ms.replay.samples` | Eligible transitions benchmarked by chronological replay |
+| `latency_ms.replay.p50`, `latency_ms.replay.p95` | Offline replay-computation percentiles in milliseconds |
+| `latency_ms.suggestion.samples` | Valid shell-observed latency samples from `shown` events |
+| `latency_ms.suggestion.p50`, `latency_ms.suggestion.p95` | Shell-observed suggestion-result percentiles in milliseconds |
 
-A percentage is `null` when its denominator is zero, and both latency values are `null` when there are no eligible transitions. Human output prints `n/a` for the same cases. This keeps empty and partially retained event stores valid without presenting missing observations as zero-latency measurements.
+A percentage is `null` when its denominator is zero. Each latency distribution has an explicit sample count and returns `null` percentiles when that count is zero. Suggestion latency counts only valid non-negative `shown` rows, so later accepted, executed, or dismissed outcomes do not duplicate one displayed suggestion. Human output prints `n/a` for unavailable distributions.
+
+Schema version 2 replaces the version 1 `latency_ms.p50` and `latency_ms.p95` fields with `latency_ms.replay` and `latency_ms.suggestion`. Use the suggestion distribution for user-facing adoption studies and the replay distribution for policy benchmarking.
 
 Config lives at `~/.config/soon/config.toml`:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,13 +25,13 @@ Every pull request runs:
 
 ## Release sequence
 
-1. Confirm `master` is clean and all v0.4 issues except the release issue are closed.
+1. Confirm `master` is clean and every artifact-blocking code or documentation issue is closed or included in the release. A research issue may remain open only when it explicitly depends on the release artifact; record that relationship in both issues.
 2. Add one `CHANGELOG.md` section and update `Cargo.toml` plus `Cargo.lock` to the same version.
 3. Run the repository checks and `cargo package --locked`.
 4. Merge the release commit.
 5. Create and push one annotated `vX.Y.Z` tag on the merged commit.
 6. The `Release Cargo and PyPI` workflow validates tag/version/changelog equality, builds every artifact, publishes Cargo first, then publishes the same artifacts to PyPI.
 7. Publish the GitHub Release from the same changelog section.
-8. Verify the exact version on crates.io and PyPI before closing the release issue and milestone.
+8. Verify the exact version on crates.io and PyPI before closing the release issue. Close the milestone only after any downstream research issues are complete.
 
 Never force-rewrite a published release tag. If a registry publication is defective, stop the other release work, record the failure, and use registry-native yanking rather than reusing the version.

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -33,8 +33,8 @@ pub fn run(config: &AppConfig, json: bool) {
         report.suggestions.executed,
         report.suggestions.execution_percent,
     );
-    print_latency("p50", report.latency_ms.p50);
-    print_latency("p95", report.latency_ms.p95);
+    print_latency_distribution("Replay", &report.latency_ms.replay);
+    print_latency_distribution("Suggestion", &report.latency_ms.suggestion);
     println!("Privacy: aggregate metrics only; no command text or paths included.");
 }
 
@@ -46,10 +46,18 @@ fn print_outcome(label: &str, count: usize, percent: Option<f64>) {
     }
 }
 
-fn print_latency(label: &str, latency_ms: Option<f64>) {
-    if let Some(latency_ms) = latency_ms {
-        println!("{label} latency: {latency_ms:.3} ms");
+fn print_latency_distribution(label: &str, latency: &report::LatencyDistribution) {
+    if let (Some(p50), Some(p95)) = (latency.p50, latency.p95) {
+        let unit = if latency.samples == 1 {
+            "sample"
+        } else {
+            "samples"
+        };
+        println!(
+            "{label} latency: p50={p50:.3} ms p95={p95:.3} ms ({} {unit})",
+            latency.samples,
+        );
     } else {
-        println!("{label} latency: n/a");
+        println!("{label} latency: n/a (0 samples)");
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -94,7 +94,7 @@ struct CandidateScore {
     latest_index: usize,
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct EventStats {
     pub command_events: usize,
     pub suggestion_events: usize,
@@ -103,6 +103,9 @@ pub struct EventStats {
     pub executed: usize,
     pub dismissed: usize,
     pub malformed_lines: usize,
+    pub shown_latency_samples: usize,
+    pub shown_p50_latency_ms: Option<f64>,
+    pub shown_p95_latency_ms: Option<f64>,
 }
 
 pub fn event_store_path() -> PathBuf {
@@ -207,13 +210,19 @@ pub fn inspect() -> EventStats {
     };
 
     let mut stats = EventStats::default();
+    let mut shown_latencies_ms = Vec::new();
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         match serde_json::from_str::<StoredEvent>(&line) {
             Ok(StoredEvent::Command(_)) => stats.command_events += 1,
             Ok(StoredEvent::Suggestion(event)) => {
                 stats.suggestion_events += 1;
                 match event.outcome {
-                    SuggestionOutcome::Shown => stats.shown += 1,
+                    SuggestionOutcome::Shown => {
+                        stats.shown += 1;
+                        if event.latency_ms.is_finite() && !event.latency_ms.is_sign_negative() {
+                            shown_latencies_ms.push(event.latency_ms);
+                        }
+                    }
                     SuggestionOutcome::Accepted => stats.accepted += 1,
                     SuggestionOutcome::Executed => stats.executed += 1,
                     SuggestionOutcome::Dismissed => stats.dismissed += 1,
@@ -222,7 +231,19 @@ pub fn inspect() -> EventStats {
             Err(_) => stats.malformed_lines += 1,
         }
     }
+    shown_latencies_ms.sort_by(f64::total_cmp);
+    stats.shown_latency_samples = shown_latencies_ms.len();
+    stats.shown_p50_latency_ms = percentile(&shown_latencies_ms, 0.50);
+    stats.shown_p95_latency_ms = percentile(&shown_latencies_ms, 0.95);
     stats
+}
+
+fn percentile(sorted_values: &[f64], percentile: f64) -> Option<f64> {
+    if sorted_values.is_empty() {
+        return None;
+    }
+    let rank = (percentile * sorted_values.len() as f64).ceil() as usize;
+    Some(sorted_values[rank.saturating_sub(1).min(sorted_values.len() - 1)])
 }
 
 pub fn clear() -> Result<(), String> {

--- a/src/report.rs
+++ b/src/report.rs
@@ -2,7 +2,7 @@ use crate::config::AppConfig;
 use crate::{events, replay};
 use serde::Serialize;
 
-pub const SCHEMA_VERSION: u8 = 1;
+pub const SCHEMA_VERSION: u8 = 2;
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct AdoptionReport {
@@ -30,6 +30,13 @@ pub struct SuggestionMetrics {
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct LatencyMetrics {
+    pub replay: LatencyDistribution,
+    pub suggestion: LatencyDistribution,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct LatencyDistribution {
+    pub samples: usize,
     pub p50: Option<f64>,
     pub p95: Option<f64>,
 }
@@ -53,8 +60,16 @@ pub fn build(config: &AppConfig) -> AdoptionReport {
             execution_percent: percent(events.executed, events.shown),
         },
         latency_ms: LatencyMetrics {
-            p50: (replay.overall.samples > 0).then(|| replay.overall.p50_ms()),
-            p95: (replay.overall.samples > 0).then(|| replay.overall.p95_ms()),
+            replay: LatencyDistribution {
+                samples: replay.overall.samples,
+                p50: (replay.overall.samples > 0).then(|| replay.overall.p50_ms()),
+                p95: (replay.overall.samples > 0).then(|| replay.overall.p95_ms()),
+            },
+            suggestion: LatencyDistribution {
+                samples: events.shown_latency_samples,
+                p50: events.shown_p50_latency_ms,
+                p95: events.shown_p95_latency_ms,
+            },
         },
     }
 }

--- a/tests/report_cli.rs
+++ b/tests/report_cli.rs
@@ -64,13 +64,17 @@ fn record_command(home: &PathBuf, id: &str, text: &str, previous_id: Option<&str
 }
 
 fn record_suggestion(home: &PathBuf, outcome: &str) {
+    record_suggestion_event(home, "suggestion-1", outcome, "7.5");
+}
+
+fn record_suggestion_event(home: &PathBuf, id: &str, outcome: &str, latency_ms: &str) {
     run(
         home,
         &[
             "events",
             "record-suggestion",
             "--id",
-            "suggestion-1",
+            id,
             "--command-event-id",
             "command-4",
             "--trigger",
@@ -82,7 +86,7 @@ fn record_suggestion(home: &PathBuf, outcome: &str) {
             "--outcome",
             outcome,
             "--latency-ms",
-            "7.5",
+            latency_ms,
         ],
     );
 }
@@ -104,6 +108,16 @@ fn populated_home() -> PathBuf {
     home
 }
 
+fn event_store_path(home: &PathBuf) -> PathBuf {
+    let inspect = run(home, &["events", "inspect"]);
+    let stdout = String::from_utf8(inspect.stdout).expect("UTF-8 inspect output");
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Event store: "))
+        .map(PathBuf::from)
+        .expect("event store path")
+}
+
 #[test]
 fn human_report_combines_replay_quality_with_adoption_outcomes() {
     let home = populated_home();
@@ -121,8 +135,12 @@ fn human_report_combines_replay_quality_with_adoption_outcomes() {
     assert!(stdout.contains("Suggestions shown: 1"), "{stdout}");
     assert!(stdout.contains("Accepted: 1 (100.0% of shown)"), "{stdout}");
     assert!(stdout.contains("Executed: 1 (100.0% of shown)"), "{stdout}");
-    assert!(stdout.contains("p50 latency:"), "{stdout}");
-    assert!(stdout.contains("p95 latency:"), "{stdout}");
+    assert!(stdout.contains("Replay latency: p50="), "{stdout}");
+    assert!(stdout.contains("p95="), "{stdout}");
+    assert!(
+        stdout.contains("Suggestion latency: p50=7.500 ms p95=7.500 ms (1 sample)"),
+        "{stdout}"
+    );
 }
 
 #[test]
@@ -135,7 +153,7 @@ fn json_report_has_a_versioned_aggregate_only_schema() {
 
     let _ = std::fs::remove_dir_all(&home);
     assert_eq!(json.as_object().expect("JSON object").len(), 4, "{json}");
-    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["schema_version"], 2);
     assert_eq!(
         json["samples"],
         serde_json::json!({
@@ -159,11 +177,40 @@ fn json_report_has_a_versioned_aggregate_only_schema() {
             .as_object()
             .expect("latency object")
             .len(),
-        2,
-        "{json}"
+        2
     );
-    assert!(json["latency_ms"]["p50"].is_number(), "{json}");
-    assert!(json["latency_ms"]["p95"].is_number(), "{json}");
+    assert_eq!(json["latency_ms"]["replay"]["samples"], 4);
+    assert!(json["latency_ms"]["replay"]["p50"].is_number(), "{json}");
+    assert!(json["latency_ms"]["replay"]["p95"].is_number(), "{json}");
+    assert_eq!(
+        json["latency_ms"]["suggestion"],
+        serde_json::json!({"samples": 1, "p50": 7.5, "p95": 7.5})
+    );
+}
+
+#[test]
+fn json_report_separates_replay_and_displayed_suggestion_latency() {
+    let home = populated_home();
+    record_suggestion_event(&home, "suggestion-2", "shown", "42.0");
+
+    let report = run(&home, &["report", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&report.stdout).expect("report is valid JSON");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert_eq!(json["schema_version"], 2, "{json}");
+    assert_eq!(json["latency_ms"]["replay"]["samples"], 4, "{json}");
+    assert!(json["latency_ms"]["replay"]["p50"].is_number(), "{json}");
+    assert!(json["latency_ms"]["replay"]["p95"].is_number(), "{json}");
+    assert_eq!(
+        json["latency_ms"]["suggestion"],
+        serde_json::json!({
+            "samples": 2,
+            "p50": 7.5,
+            "p95": 42.0
+        }),
+        "accepted and executed rows must not duplicate suggestion-1: {json}"
+    );
 }
 
 #[test]
@@ -187,8 +234,11 @@ fn empty_store_reports_unavailable_rates_and_latency_without_failing() {
         human.contains("Executed: 0 (n/a; no shown suggestions)"),
         "{human}"
     );
-    assert!(human.contains("p50 latency: n/a"), "{human}");
-    assert!(human.contains("p95 latency: n/a"), "{human}");
+    assert!(human.contains("Replay latency: n/a (0 samples)"), "{human}");
+    assert!(
+        human.contains("Suggestion latency: n/a (0 samples)"),
+        "{human}"
+    );
     assert_eq!(json["samples"]["eligible_transitions"], 0);
     assert_eq!(
         json["samples"]["prediction_coverage_percent"],
@@ -202,8 +252,18 @@ fn empty_store_reports_unavailable_rates_and_latency_without_failing() {
         json["suggestions"]["execution_percent"],
         serde_json::Value::Null
     );
-    assert_eq!(json["latency_ms"]["p50"], serde_json::Value::Null);
-    assert_eq!(json["latency_ms"]["p95"], serde_json::Value::Null);
+    assert_eq!(json["latency_ms"]["replay"]["samples"], 0);
+    assert_eq!(json["latency_ms"]["replay"]["p50"], serde_json::Value::Null);
+    assert_eq!(json["latency_ms"]["replay"]["p95"], serde_json::Value::Null);
+    assert_eq!(json["latency_ms"]["suggestion"]["samples"], 0);
+    assert_eq!(
+        json["latency_ms"]["suggestion"]["p50"],
+        serde_json::Value::Null
+    );
+    assert_eq!(
+        json["latency_ms"]["suggestion"]["p95"],
+        serde_json::Value::Null
+    );
 }
 
 #[test]
@@ -224,13 +284,17 @@ fn partially_populated_store_keeps_counts_but_not_undefined_rates() {
         json["suggestions"]["acceptance_percent"],
         serde_json::Value::Null
     );
-    assert_eq!(json["latency_ms"]["p95"], serde_json::Value::Null);
+    assert_eq!(json["latency_ms"]["replay"]["p95"], serde_json::Value::Null);
+    assert_eq!(
+        json["latency_ms"]["suggestion"]["p95"],
+        serde_json::Value::Null
+    );
 }
 
 #[test]
 fn reports_never_emit_sensitive_values_from_legacy_event_rows() {
     let home = isolated_home();
-    let store = home.join(".local/share/soon/events.jsonl");
+    let store = event_store_path(&home);
     std::fs::create_dir_all(store.parent().expect("event directory"))
         .expect("create event directory");
     let sensitive_command = "export OPENAI_API_KEY=sk-private-report-marker";
@@ -283,4 +347,65 @@ fn reports_never_emit_sensitive_values_from_legacy_event_rows() {
             "report leaked {sensitive}: {combined}"
         );
     }
+}
+
+#[test]
+fn suggestion_latency_ignores_invalid_legacy_values_and_non_shown_outcomes() {
+    let home = isolated_home();
+    let store = event_store_path(&home);
+    std::fs::create_dir_all(store.parent().expect("event directory"))
+        .expect("create event directory");
+    let rows = [
+        serde_json::json!({
+            "kind": "suggestion",
+            "schema_version": 1,
+            "id": "valid-shown",
+            "command_event_id": null,
+            "trigger": "manual",
+            "candidate_source": "history",
+            "command": "cargo test",
+            "outcome": "shown",
+            "latency_ms": 12.5
+        }),
+        serde_json::json!({
+            "kind": "suggestion",
+            "schema_version": 1,
+            "id": "invalid-shown",
+            "command_event_id": null,
+            "trigger": "manual",
+            "candidate_source": "history",
+            "command": "cargo check",
+            "outcome": "shown",
+            "latency_ms": -4.0
+        }),
+        serde_json::json!({
+            "kind": "suggestion",
+            "schema_version": 1,
+            "id": "valid-shown",
+            "command_event_id": null,
+            "trigger": "manual",
+            "candidate_source": "history",
+            "command": "cargo test",
+            "outcome": "accepted",
+            "latency_ms": 12.5
+        }),
+    ];
+    let encoded = rows
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&store, format!("{encoded}\n")).expect("write legacy event rows");
+
+    let report = run(&home, &["report", "--json"]);
+    let json: serde_json::Value =
+        serde_json::from_slice(&report.stdout).expect("report is valid JSON");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert_eq!(json["suggestions"]["shown"], 2, "{json}");
+    assert_eq!(
+        json["latency_ms"]["suggestion"],
+        serde_json::json!({"samples": 1, "p50": 12.5, "p95": 12.5}),
+        "{json}"
+    );
 }

--- a/tests/site_smoke.py
+++ b/tests/site_smoke.py
@@ -73,6 +73,7 @@ def main() -> None:
     assert "cargo install soon" in html
     assert "python -m pip install soon-bin" in html
     assert 'eval "$(soon init zsh)"' in html
+    assert "v0.4.1" in html
     assert "No automatic execution" in html
 
     for attribute, reference in parser.references:

--- a/www/index.html
+++ b/www/index.html
@@ -30,7 +30,7 @@
     <main id="main">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="eyebrow">v0.4 beta · Zsh · local by default</p>
+          <p class="eyebrow">v0.4.1 beta · Zsh · local by default</p>
           <h1 id="hero-title">Your terminal already knows what comes next.</h1>
           <p class="lede">
             soon learns recurring command transitions, then places one complete
@@ -39,8 +39,8 @@
 
           <div class="hero-actions">
             <a class="button button-primary" href="#install">Install the beta</a>
-            <a class="button button-secondary" href="https://github.com/HsiangNianian/soon/releases/tag/v0.4.0">
-              Read the v0.4 release
+            <a class="button button-secondary" href="https://github.com/HsiangNianian/soon/releases/tag/v0.4.1">
+              Read the v0.4.1 release
             </a>
           </div>
 
@@ -108,7 +108,7 @@
           <p class="eyebrow">Three commands</p>
           <h2 id="install-title">Meet the next prompt.</h2>
           <p>
-            Install the same v0.4 release from Cargo or PyPI, then opt in for
+            Install the same v0.4.1 release from Cargo or PyPI, then opt in for
             the current Zsh session.
           </p>
         </div>


### PR DESCRIPTION
## Summary

- ship `soon report` in the v0.4.1 package metadata and documentation
- split schema v2 latency into chronological replay and user-visible suggestion distributions
- count only valid non-negative `shown` events for suggestion latency, avoiding lifecycle-row duplication
- clarify the release gate for research that depends on the published artifact

## Why

The local Zsh pilot was blocked because the v0.4.0 registry artifact predates `soon report`. The report also labeled replay-computation latency as the shell suggestion latency users experience. This release-prep change makes the command publishable and gives Issue #27 the correct metric contract.

## User impact

`soon report --json` now emits `latency_ms.replay` and `latency_ms.suggestion`, each with `samples`, `p50`, and `p95`. This is a schema v2 breaking change from the two flat v1 latency fields. Human output uses the same explicit labels.

## Validation

- `cargo test --locked` — 48 passed
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `zsh tests/release_smoke.zsh`
- `cargo package --locked --allow-dirty`
- `uvx pre-commit run --all-files`
- `python3 tests/site_smoke.py`
- `cargo fmt --check`
- `git diff --check`

Refs #30
