### PR TITLE
fix: preserve semicolon-containing Zsh history commands

### DIFF
--- a/src/history_import.rs
+++ b/src/history_import.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::config::AppConfig;
 use crate::events::{self, CommandEvent, SCHEMA_VERSION};
 use crate::privacy;
+use crate::shell::zsh::{decode_history_line, DecodedHistoryEntry};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ImportStats {
@@ -71,7 +72,7 @@ fn prepare_zsh(
                 previous_event_id = None;
                 continue;
             };
-            match parse_zsh_line(line) {
+            match decode_history_line(line) {
                 Ok(Some(entry)) => {
                     if entry.command.chars().any(char::is_control) {
                         stats.malformed += 1;
@@ -111,47 +112,7 @@ fn prepare_zsh(
     Ok((stats, commands))
 }
 
-struct ZshEntry<'a> {
-    command: &'a str,
-    started_at_ms: Option<i64>,
-    duration_ms: Option<u64>,
-}
-
-fn parse_zsh_line(line: &str) -> Result<Option<ZshEntry<'_>>, ()> {
-    let line = line.trim();
-    if line.is_empty() {
-        return Ok(None);
-    }
-
-    if let Some(metadata_and_command) = line.strip_prefix(": ") {
-        if let Some((metadata, command)) = metadata_and_command.split_once(';') {
-            if metadata.contains(':') {
-                let (timestamp, duration) = metadata.split_once(':').ok_or(())?;
-                let timestamp = timestamp.parse::<i64>().map_err(|_| ())?;
-                let duration = duration.parse::<u64>().map_err(|_| ())?;
-                let started_at_ms = timestamp.checked_mul(1000).ok_or(())?;
-                let duration_ms = duration.checked_mul(1000).ok_or(())?;
-                let command = command.trim();
-                if command.is_empty() {
-                    return Err(());
-                }
-                return Ok(Some(ZshEntry {
-                    command,
-                    started_at_ms: Some(started_at_ms),
-                    duration_ms: Some(duration_ms),
-                }));
-            }
-        }
-    }
-
-    Ok(Some(ZshEntry {
-        command: line,
-        started_at_ms: None,
-        duration_ms: None,
-    }))
-}
-
-fn stable_event_id(entry: &ZshEntry<'_>, previous_event_id: Option<&str>) -> String {
+fn stable_event_id(entry: &DecodedHistoryEntry<'_>, previous_event_id: Option<&str>) -> String {
     let material = format!(
         "{}\0{}\0{}\0{}",
         entry

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -2,29 +2,57 @@ use std::io::{BufRead, Read};
 
 use super::HistoryItem;
 
+pub(crate) struct DecodedHistoryEntry<'a> {
+    pub command: &'a str,
+    pub started_at_ms: Option<i64>,
+    pub duration_ms: Option<u64>,
+}
+
 pub fn integration_script() -> &'static str {
     include_str!("soon.zsh")
 }
 
 pub fn parse_zsh_history<R: Read>(reader: std::io::BufReader<R>, result: &mut Vec<HistoryItem>) {
     for line in reader.lines().map_while(Result::ok) {
-        let line = line.trim().to_string();
-        if line.is_empty() {
-            continue;
-        }
-
-        let cmd = if let Some(semi) = line.find(';') {
-            let (_, rest) = line.split_at(semi + 1);
-            rest.trim()
-        } else {
-            &line
-        };
-
-        if !cmd.is_empty() {
+        if let Ok(Some(entry)) = decode_history_line(&line) {
             result.push(HistoryItem {
-                cmd: cmd.to_string(),
+                cmd: entry.command.to_string(),
                 path: None,
             });
         }
     }
+}
+
+pub(crate) fn decode_history_line(line: &str) -> Result<Option<DecodedHistoryEntry<'_>>, ()> {
+    let line = line.trim();
+    if line.is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(metadata_and_command) = line.strip_prefix(": ") {
+        if let Some((metadata, command)) = metadata_and_command.split_once(';') {
+            if metadata.contains(':') {
+                let (timestamp, duration) = metadata.split_once(':').ok_or(())?;
+                let timestamp = timestamp.parse::<i64>().map_err(|_| ())?;
+                let duration = duration.parse::<u64>().map_err(|_| ())?;
+                let started_at_ms = timestamp.checked_mul(1000).ok_or(())?;
+                let duration_ms = duration.checked_mul(1000).ok_or(())?;
+                let command = command.trim();
+                if command.is_empty() {
+                    return Err(());
+                }
+                return Ok(Some(DecodedHistoryEntry {
+                    command,
+                    started_at_ms: Some(started_at_ms),
+                    duration_ms: Some(duration_ms),
+                }));
+            }
+        }
+    }
+
+    Ok(Some(DecodedHistoryEntry {
+        command: line,
+        started_at_ms: None,
+        duration_ms: None,
+    }))
 }

--- a/tests/zsh_cli.rs
+++ b/tests/zsh_cli.rs
@@ -94,6 +94,76 @@ fn raw_prediction_uses_the_submitted_command_as_context() {
 }
 
 #[test]
+fn manual_prediction_preserves_plain_commands_containing_semicolons() {
+    let home = isolated_home();
+    std::fs::write(
+        home.join(".zsh_history"),
+        concat!(
+            "git status\n",
+            "printf before; echo after\n",
+            "echo first-break\n",
+            "git diff\n",
+            "printf before; echo after\n",
+            "echo second-break\n",
+            "git log\n",
+            "cargo test --workspace\n",
+            "git show\n",
+        ),
+    )
+    .expect("write Zsh history");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soon"))
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .args(["--shell", "zsh", "--ngram", "1", "now"])
+        .output()
+        .expect("run manual prediction");
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 prediction");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        output.status.success(),
+        "manual prediction failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("printf before; echo after"), "{stdout}");
+}
+
+#[test]
+fn manual_prediction_decodes_extended_history_metadata() {
+    let home = isolated_home();
+    std::fs::write(
+        home.join(".zsh_history"),
+        concat!(
+            ": 1720000000:1;git status\n",
+            ": 1720000001:1;cargo test --workspace\n",
+            ": 1720000002:1;echo break\n",
+            ": 1720000003:1;git diff\n",
+            ": 1720000004:1;cargo test --workspace\n",
+            ": 1720000005:1;git show\n",
+        ),
+    )
+    .expect("write extended Zsh history");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_soon"))
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .args(["--shell", "zsh", "--ngram", "1", "now"])
+        .output()
+        .expect("run manual prediction");
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 prediction");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        output.status.success(),
+        "manual prediction failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(stdout.contains("cargo test --workspace"), "{stdout}");
+    assert!(!stdout.contains("1720000001:1"), "{stdout}");
+}
+
+#[test]
 fn debug_output_does_not_print_sensitive_history_text() {
     let home = isolated_home();
     let secret = "debug-secret-value";


### PR DESCRIPTION
## What changed

- preserve plain Zsh history commands that contain semicolons
- share one Zsh history decoder between manual prediction and event import
- cover plain and extended history through the real CLI

## Root cause

The manual history parser split every line at its first semicolon, while the event importer only removed a validated extended-history metadata prefix. The two paths therefore interpreted the same plain command differently.

## User impact

Commands such as `printf before; echo after` remain complete prediction candidates instead of being truncated to `echo after`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` — 50 passed
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/release_smoke.zsh`
- `python3 tests/site_smoke.py`

Fixes #34

## Summary by Sourcery

统一 Zsh 历史记录的解码方式，使手动预测和事件导入在解析普通历史和扩展历史时保持一致，从而保留包含分号的完整命令。

Bug Fixes:
- 确保手动 Zsh 历史预测在处理包含分号的命令时，能够保留完整命令，而不是将其截断。

Enhancements:
- 引入一个共享的 Zsh 历史解码器，由 CLI 预测路径和 Zsh 历史导入器共同复用，以实现行为一致性。

Tests:
- 添加 CLI 集成测试，用于覆盖包含分号的普通 Zsh 历史以及扩展历史元数据解码的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify Zsh history decoding so manual prediction and event import interpret both plain and extended history consistently, preserving commands that contain semicolons.

Bug Fixes:
- Ensure manual Zsh history predictions preserve full commands that include semicolons instead of truncating them.

Enhancements:
- Introduce a shared Zsh history decoder reused by both the CLI prediction path and the Zsh history importer for consistent behavior.

Tests:
- Add CLI integration tests covering plain Zsh history with semicolons and extended-history metadata decoding.

</details>