### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to soon are documented here.
 
+## 0.4.2 - 2026-07-29
+
+soon 0.4.2 is a focused Zsh history-correctness patch. It keeps compound
+commands intact across manual prediction and event import while preserving the
+existing extended-history metadata behavior.
+
+### Fixed
+
+- Preserve plain Zsh history commands containing semicolons by sharing one
+  decoder between on-demand prediction and event import
+  ([#36](https://github.com/HsiangNianian/soon/pull/36)).
+
+### Documentation
+
+- Added the reusable v0.4.1 launch kit and its rendered campaign assets
+  ([#33](https://github.com/HsiangNianian/soon/pull/33)).
+
+[Full diff](https://github.com/HsiangNianian/soon/compare/v0.4.1...v0.4.2)
+
 ## 0.4.1 - 2026-07-27
 
 soon 0.4.1 is the adoption build for the local terminal-agent beta. It makes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "soon"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soon"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Local-first prediction for your next full shell command"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A local-first terminal agent that predicts, repairs, and suggests your next full
 [![CI](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml/badge.svg)](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-[Website](https://soon.hydroroll.team) · [v0.4.1 adoption build](https://github.com/HsiangNianian/soon/releases/tag/v0.4.1) · [Roadmap](https://github.com/users/HsiangNianian/projects/7)
+[Website](https://soon.hydroroll.team) · [v0.4.2 Zsh parser patch](https://github.com/HsiangNianian/soon/releases/tag/v0.4.2) · [Roadmap](https://github.com/users/HsiangNianian/projects/7)
 
 </div>
 
-> **Beta status:** v0.4.1 ships the first opt-in Zsh ghost-suggestion loop plus a privacy-safe adoption report. Interactive integration is supported on native Linux and macOS; other shells and packaged platforms remain experimental unless listed in the [release contract](RELEASING.md).
+> **Beta status:** v0.4.2 ships the opt-in Zsh ghost-suggestion loop, a privacy-safe adoption report, and correct handling for compound commands in Zsh history. Interactive integration is supported on native Linux and macOS; other shells and packaged platforms remain experimental unless listed in the [release contract](RELEASING.md).
 
 <a href="https://soon.hydroroll.team">
   <img src="www/assets/soon-demo.svg" alt="An 18-second terminal demo: a failed Git command triggers a local Repair suggestion, Ctrl-F accepts it into the editable buffer, and the user decides when to execute it.">
@@ -23,7 +23,7 @@ A local-first terminal agent that predicts, repairs, and suggests your next full
 
 ## Try the beta
 
-Install the same v0.4.1 release through Cargo or PyPI:
+Install the same v0.4.2 release through Cargo or PyPI:
 
 ```bash
 cargo install soon

--- a/tests/site_smoke.py
+++ b/tests/site_smoke.py
@@ -73,7 +73,7 @@ def main() -> None:
     assert "cargo install soon" in html
     assert "python -m pip install soon-bin" in html
     assert 'eval "$(soon init zsh)"' in html
-    assert "v0.4.1" in html
+    assert "v0.4.2" in html
     assert "No automatic execution" in html
 
     for attribute, reference in parser.references:

--- a/www/index.html
+++ b/www/index.html
@@ -30,7 +30,7 @@
     <main id="main">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="eyebrow">v0.4.1 beta · Zsh · local by default</p>
+          <p class="eyebrow">v0.4.2 beta · Zsh · local by default</p>
           <h1 id="hero-title">Your terminal already knows what comes next.</h1>
           <p class="lede">
             soon learns recurring command transitions, then places one complete
@@ -39,8 +39,8 @@
 
           <div class="hero-actions">
             <a class="button button-primary" href="#install">Install the beta</a>
-            <a class="button button-secondary" href="https://github.com/HsiangNianian/soon/releases/tag/v0.4.1">
-              Read the v0.4.1 release
+            <a class="button button-secondary" href="https://github.com/HsiangNianian/soon/releases/tag/v0.4.2">
+              Read the v0.4.2 release
             </a>
           </div>
 
@@ -108,7 +108,7 @@
           <p class="eyebrow">Three commands</p>
           <h2 id="install-title">Meet the next prompt.</h2>
           <p>
-            Install the same v0.4.1 release from Cargo or PyPI, then opt in for
+            Install the same v0.4.2 release from Cargo or PyPI, then opt in for
             the current Zsh session.
           </p>
         </div>


### PR DESCRIPTION
## Release

Prepare v0.4.2 for the completed Zsh parser patch milestone.

## Changes

- align `Cargo.toml` and `Cargo.lock` on 0.4.2
- add the v0.4.2 changelog and exact release notes
- update README and the live-site source to the current patch release
- advance the site smoke contract to v0.4.2

## Local release gates

- `cargo fmt --all -- --check`
- `cargo test --locked` — 50 passed
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/release_smoke.zsh` — installed and uninstalled `soon 0.4.2`
- `cargo package --locked --allow-dirty` — packaged and verified
- `python3 tests/site_smoke.py`
- `npx wrangler deploy --dry-run`

The annotated tag, Cargo/PyPI publication, GitHub Release, live deploy, and registry verification remain gated on this PR merging.

Tracks #35

## Summary by Sourcery

准备 v0.4.2 版本发布，包括修复 Zsh 历史记录正确性问题和更新文档。

Bug 修复：
- 通过统一预测和事件导入之间的解码方式，确保带分号的复合 Zsh 历史命令能够被正确保留。

构建：
- 将 crate 版本提升到 v0.4.2，并为新版本重新生成 Cargo.lock。

文档：
- 添加 0.4.2 的更新日志条目并链接到完整差异。
- 更新 README 和网站文案，以引用 v0.4.2 Zsh 解析器补丁版本，并描述其对 Zsh 复合命令处理方式的修正。

测试：
- 更新站点冒烟测试的预期结果，使其匹配 v0.4.2 版本内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the v0.4.2 release, including Zsh history correctness fixes and documentation updates.

Bug Fixes:
- Ensure compound Zsh history commands with semicolons are preserved by unifying decoding between prediction and event import.

Build:
- Bump the crate version to v0.4.2 and regenerate Cargo.lock for the new release.

Documentation:
- Add the 0.4.2 changelog entry and link to the full diff.
- Update the README and website copy to reference the v0.4.2 Zsh parser patch release and describe its corrected Zsh compound command handling.

Tests:
- Update the site smoke test expectations to the v0.4.2 release content.

</details>