### PR TITLE
feat: add contextual prediction policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to soon are documented here.
 
+## Unreleased
+
+### Added
+
+- Added a contextual full-command ranker with separate candidate-source
+  and ranker boundaries, smoothed transition and context evidence, repository
+  and branch capture, feedback-aware ranking, explainable debug output, and a
+  chronological promotion comparison against the v0.4 baseline. It is the v0.5
+  source default after passing the quality and latency gate; `v0.4-baseline`
+  remains an explicit fallback ([#16](https://github.com/HsiangNianian/soon/issues/16)).
+
 ## 0.4.2 - 2026-07-29
 
 soon 0.4.2 is a focused Zsh history-correctness patch. It keeps compound

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ At an empty prompt, soon computes in the background and renders one dim full-com
 
 The default prediction path uses local history, not a model or network service. It can choose a Next-step suggestion after success, a Repair suggestion after failure, or predict on demand when you run `soon`.
 
-> **Help validate the beta:** join the [ten-user Zsh pilot](https://github.com/HsiangNianian/soon/issues/27). The study asks for privacy-safe aggregate counters and qualitative feedback, never raw command text.
+> **v0.5 development:** the source tree defaults to the local contextual policy after it passed the replay promotion gate. The published v0.4.2 package still uses the deterministic baseline.
 
 ## The idea
 
@@ -105,6 +105,9 @@ soon stats
 # Measure the current policy against past local transitions
 soon replay
 
+# Compare both policies, or switch back to the v0.4 fallback
+soon config set prediction.policy v0.4-baseline
+
 # Export aggregate adoption metrics that are safe to share
 soon report
 soon report --json
@@ -129,21 +132,19 @@ The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and t
 
 The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). Work is tracked in the public [Personal Terminal Agent Project](https://github.com/users/HsiangNianian/projects/7).
 
-## How the current predictor works
+## How the current predictors work
 
-1. Detect the active shell and read its history file.
-2. Reduce recent commands to executable names only for matching workflow context.
-3. Keep each candidate as the complete historical command, including arguments.
-4. Accumulate repeated transition evidence and weight newer evidence more heavily.
-5. Print the highest-ranked full command without presenting the heuristic as calibrated confidence.
+The v0.4 baseline matches recurring transitions, preserves complete historical commands including arguments, and deterministically ranks result, directory, frequency, and recency evidence.
 
-This baseline is deliberately simple. A more complex ranker must beat it under `soon replay` before it replaces the deterministic hot path.
+The contextual policy separates candidate retrieval from ranking, then combines first- and second-order transitions, cwd, optional repository and branch, original time, result, duration, frequency, recency, and accepted/executed feedback. Missing metadata contributes no evidence. Its additive smoothing, weights, debug contract, and deterministic tie-breaking are documented in [Contextual prediction policy](docs/contextual-policy.md).
+
+The v0.5 source promotes contextual after it improved exact top-1 without reducing coverage or exceeding the 20 ms p95 budget in both the deterministic fixture and a local aggregate replay. `v0.4-baseline` remains an explicit offline fallback.
 
 ## Agent roadmap
 
 The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) combines safe command lifecycle events, explicit `soon`, Next-step after success, Repair after failure, a private history-import path, and measured local replay.
 
-The [v0.4.1 Adoption Sprint](https://github.com/HsiangNianian/soon/milestone/3) makes that loop easy to discover, validates it with ten Zsh users, and adds a privacy-safe report before the prediction policy becomes more complex.
+The closed [v0.4.1 Adoption Sprint](https://github.com/HsiangNianian/soon/milestone/3) added the public demo, launch assets, and privacy-safe report. The planned ten-user pilot and final timed launch measurements were explicitly closed as not planned rather than reported as completed.
 
 The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) then measures a contextual probabilistic ranker in [#16](https://github.com/HsiangNianian/soon/issues/16) before adding opt-in local-model and OpenAI-compatible candidate sources in [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
 
@@ -176,7 +177,7 @@ export SOON_LLM_API_KEY
 
 Ollama can run without a credential. The legacy `llm.api_key` setting is rejected.
 
-The Zsh lifecycle integration stores local command and suggestion events in a retained JSONL log under the operating system's application-data directory. Inspect its exact path, schema version, retention, and aggregate counts without printing command text:
+The Zsh lifecycle integration stores local command and suggestion events in a retained JSONL log under the operating system's application-data directory. When cwd is inside a Git worktree, the background recorder also reads the repository root and symbolic branch directly from `.git/HEAD`; it does not spawn `git`. Inspect the store's exact path, schema version, retention, and aggregate counts without printing command text:
 
 ```bash
 soon events inspect
@@ -207,7 +208,7 @@ soon events import-zsh \
 
 Plain command-per-line history and Zsh extended history (`: <epoch>:<duration>;<command>`) are supported. Extended timestamps and durations are preserved; unavailable cwd, exit status, and plain-history timestamps remain unknown. Preview and import summaries report importable, sensitive, malformed, duplicate, and already-imported counts without printing command text. Stable event IDs make repeated imports idempotent, including identical rotated files.
 
-Measure the deterministic policy against that local event memory:
+Compare the v0.4 baseline and contextual policy against that local event memory:
 
 ```bash
 soon replay
@@ -215,9 +216,9 @@ soon replay
 
 Replay follows JSONL append order rather than event timestamps. For each linked command transition it predicts first, scores the result, and only then exposes that transition to later samples, so future observations cannot leak into training. Unknown exit status is classified as `manual`; exit status zero is `next-step`; any other status is `repair`.
 
-`Samples` counts eligible linked transitions. Coverage is predictions divided by samples, and top-1 match is exact command matches divided by all samples. Overall and per-trigger rows include p50/p95 prediction latency. Candidate-source rows compare deterministic history with contextual policy, local model, or remote-provider suggestions when those sources have recorded a `shown` event before the actual next command. Model attempts aligned to a later command also report timeout, invalid-output, and deterministic-fallback rates.
+`Samples` counts eligible linked transitions. Coverage is predictions divided by samples, and top-1 match is exact command matches divided by all samples. Overall and per-trigger rows preserve the v0.4 baseline metrics. The policy comparison runs both baseline and contextual prediction through the same production module and reports coverage, top-1, p50, and p95 for each. Candidate-source rows retain the computed deterministic-history baseline and separately score other suggestions that were actually recorded before the next command. Model attempts aligned to a later command also report timeout, invalid-output, and deterministic-fallback rates.
 
-The report is aggregate-only: it prints no command text and performs no upload. The deterministic CI fixture has a Zsh hot-path p95 budget of **20 ms**; `soon replay` prints `PASS` or `FAIL` against that budget on the current local event set.
+The report is aggregate-only: it prints no command text and performs no upload. The deterministic CI fixture has a Zsh hot-path p95 budget of **20 ms**. Replay also prints a contextual promotion gate that requires strictly better top-1, no coverage regression, and contextual p95 at or below that budget.
 
 Export the smaller adoption report when sharing beta feedback:
 
@@ -255,6 +256,8 @@ soon config init
 soon config path
 soon config get general.ngram
 soon config set general.ngram 5
+soon config get prediction.policy
+soon config set prediction.policy v0.4-baseline  # explicit fallback
 soon config set update.channel cargo  # or pip
 ```
 
@@ -276,7 +279,7 @@ soon update             Check the configured release channel
 
 ## Contributing
 
-Start with [RFC #4](https://github.com/HsiangNianian/soon/issues/4), then choose an unblocked issue from the [v0.4.1 Adoption Sprint](https://github.com/HsiangNianian/soon/milestone/3). The contextual ranker and optional model sources remain sequenced behind real-user validation.
+Start with [RFC #4](https://github.com/HsiangNianian/soon/issues/4), then choose an open issue from the [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2). The contextual ranker is tracked in [#16](https://github.com/HsiangNianian/soon/issues/16); optional model-backed sources remain sequenced in [#17](https://github.com/HsiangNianian/soon/issues/17).
 
 For local verification:
 

--- a/docs/contextual-policy.md
+++ b/docs/contextual-policy.md
@@ -1,0 +1,72 @@
+# Contextual prediction policy
+
+The contextual policy is the local-only default in the v0.5 development source after passing the replay promotion gate. Switch between it and the v0.4 fallback with:
+
+```bash
+soon config set prediction.policy contextual
+soon config set prediction.policy v0.4-baseline
+```
+
+The published v0.4.2 package still defaults to `v0.4-baseline`. Run `soon replay` after installing a v0.5 build; it evaluates both policies on the same chronological prefixes without exposing command text.
+
+## Boundaries
+
+Candidate retrieval and ranking are separate interfaces in `src/prediction.rs`:
+
+- `CandidateSource` retrieves safe, complete command strings and attaches a source to every candidate.
+- `Ranker` selects one candidate from the retrieved set.
+
+The v0.4 baseline retrieves matching first-order transitions and applies its deterministic frequency, result, directory, and recency ordering. The contextual policy retrieves complete commands from event history. When any first-order transition is available, unrelated candidates are removed before ranking; otherwise the full safe history provides a cold-start fallback.
+
+## Evidence
+
+The contextual ranker combines these local signals:
+
+| Signal | Historical comparison |
+|---|---|
+| First-order transition | command immediately before the candidate equals the completed command |
+| Second-order transition | command before that transition equals the current event's predecessor |
+| Directory | candidate event and current event have the same cwd |
+| Repository and branch | optional values captured by reading `.git/HEAD`, without spawning `git` |
+| Time | six four-hour UTC buckets plus weekday from the original event timestamp |
+| Result | success/failure class of the historical predecessor and current event |
+| Duration | predecessor duration in `<1s`, `1-10s`, `10-60s`, or `>=60s` |
+| Frequency and recency | smoothed occurrence prior and normalized latest event position |
+| Feedback | accepted adds 2 evidence units; executed adds 4; shown and dismissed add none |
+
+Missing values contribute no term. Imported history therefore does not acquire an invented time, directory, result, duration, repository, or branch.
+
+## Smoothing and ordering
+
+For a categorical signal with `m` matches among `n` known observations and `k` possible buckets, the ranker adds the log likelihood ratio:
+
+```text
+ln(((m + 1) * k) / (n + k))
+```
+
+This is additive smoothing relative to a uniform prior. The frequency prior is `ln((occurrences + 1) / (all occurrences + candidate count))`.
+
+The log-linear weights are:
+
+| Signal | Weight |
+|---|---:|
+| Second-order transition | 2.50 |
+| First-order transition | 2.00 |
+| Directory | 1.50 |
+| Repository | 1.25 |
+| Branch | 1.25 |
+| Result | 1.50 |
+| Hour bucket | 0.75 |
+| Weekday | 0.75 |
+| Duration bucket | 0.75 |
+| Feedback `ln(1 + units)` | 1.50 |
+| Frequency prior | 1.00 |
+| Normalized recency | 0.25 |
+
+Scores are ranking evidence, not calibrated confidence. Ties resolve by evidence count, latest event index, then the complete command string, making output deterministic across processes.
+
+## Debug and promotion gate
+
+`soon --debug ... now --raw` leaves the raw command on stdout and prints only the selected policy, candidate source, and contributing signal-group names to stderr. It does not print candidates, stored context values, or a confidence claim.
+
+`soon replay` reports coverage, exact top-1 match, p50, and p95 for both `v0.4-baseline` and `contextual-policy`. The contextual promotion gate passes only when contextual top-1 is strictly better, coverage is no worse, and contextual p95 is at most 20 ms. The gate is evidence for a release decision; running Replay does not edit configuration.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,12 +30,18 @@ pub enum Commands {
         /// Print only the predicted command
         #[arg(long)]
         raw: bool,
+        /// Prefix raw output with the selected prediction source
+        #[arg(long, hide = true, requires = "raw")]
+        include_source: bool,
         /// Include the command that just started in the prediction context
         #[arg(long, hide = true, requires = "raw")]
         after: Option<String>,
         /// Exit status of the completed command
         #[arg(long, hide = true, requires = "after", allow_hyphen_values = true)]
         exit_code: Option<i32>,
+        /// Event id of the completed command
+        #[arg(long, hide = true, requires = "after")]
+        event_id: Option<String>,
         /// Working directory of the completed command
         #[arg(long, hide = true, requires = "after")]
         cwd: Option<String>,

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -75,6 +75,7 @@ fn get_value(key: &str) {
             eprintln!("  general.shell, general.ngram, general.ignored_commands");
             eprintln!("  update.channel");
             eprintln!("  events.retention");
+            eprintln!("  prediction.policy");
             eprintln!("  privacy.excluded_literals, privacy.excluded_patterns");
             eprintln!("  llm.provider, llm.api_url, llm.api_key_env, llm.model, llm.prompt");
             std::process::exit(1);

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -20,20 +20,25 @@ pub fn run(action: EventsAction, config: &AppConfig) {
             exit_code,
             shell,
             previous_id,
-        } => record_command(
-            CommandEvent {
-                schema_version: SCHEMA_VERSION,
-                id,
-                command,
-                cwd: Some(cwd),
-                started_at_ms: Some(started_at_ms),
-                duration_ms: Some(duration_ms),
-                exit_code: Some(exit_code),
-                shell,
-                previous_event_id: previous_id,
-            },
-            config,
-        ),
+        } => {
+            let (repository, branch) = events::discover_git_context(&cwd);
+            record_command(
+                CommandEvent {
+                    schema_version: SCHEMA_VERSION,
+                    id,
+                    command,
+                    cwd: Some(cwd),
+                    repository,
+                    branch,
+                    started_at_ms: Some(started_at_ms),
+                    duration_ms: Some(duration_ms),
+                    exit_code: Some(exit_code),
+                    shell,
+                    previous_event_id: previous_id,
+                },
+                config,
+            );
+        }
         EventsAction::RecordSuggestion {
             id,
             command_event_id,

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -12,7 +12,9 @@ use crate::shell::{self, HistoryItem, ShellKind};
 pub struct InvocationContext<'a> {
     pub after: Option<&'a str>,
     pub exit_code: Option<i32>,
+    pub event_id: Option<&'a str>,
     pub cwd: Option<&'a str>,
+    pub include_source: bool,
 }
 
 pub fn run(
@@ -25,9 +27,20 @@ pub fn run(
 ) {
     if raw {
         if let (Some(command), Some(exit_code)) = (context.after, context.exit_code) {
-            if let Some(suggestion) = events::predict_after(command, exit_code, context.cwd, config)
+            if let Some(suggestion) =
+                events::predict_after(command, exit_code, context.event_id, context.cwd, config)
             {
-                print_raw_suggestion(Some(suggestion));
+                if debug {
+                    eprintln!("Prediction details:");
+                    eprintln!("  Policy: {}", suggestion.policy.label());
+                    eprintln!("  Candidate source: {}", suggestion.candidate_source);
+                    eprintln!("  Signal groups: {}", suggestion.signal_groups.join(", "));
+                }
+                print_raw_suggestion(
+                    Some(suggestion.command),
+                    suggestion.policy.event_source(),
+                    context.include_source,
+                );
                 return;
             }
         }
@@ -52,7 +65,7 @@ pub fn run(
         predict::predict_next_command(&history, ngram, &cache_cmds, config, debug && !raw);
 
     if raw {
-        print_raw_suggestion(suggestion);
+        print_raw_suggestion(suggestion, "deterministic-history", context.include_source);
         return;
     }
 
@@ -113,9 +126,13 @@ pub fn run(
     }
 }
 
-fn print_raw_suggestion(suggestion: Option<String>) {
+fn print_raw_suggestion(suggestion: Option<String>, source: &str, include_source: bool) {
     if let Some(cmd) = suggestion.filter(|cmd| !cmd.chars().any(char::is_control)) {
-        println!("{cmd}");
+        if include_source {
+            println!("{source}\t{cmd}");
+        } else {
+            println!("{cmd}");
+        }
     }
 }
 

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -1,4 +1,5 @@
 use crate::config::AppConfig;
+use crate::prediction::PolicyKind;
 use crate::replay::{self, Metrics, Trigger};
 
 pub fn run(config: &AppConfig) {
@@ -33,6 +34,22 @@ pub fn run(config: &AppConfig) {
         );
     }
     println!();
+    println!("Policy comparison:");
+    print_policy(PolicyKind::V04Baseline, &report.baseline);
+    print_policy(PolicyKind::Contextual, &report.contextual);
+    println!(
+        "Contextual promotion gate: {} (requires top-1 > baseline and p95 <= 20 ms)",
+        if report.contextual_promotion_passes() {
+            "PASS"
+        } else {
+            "FAIL"
+        }
+    );
+    println!(
+        "Configured policy: {}",
+        crate::prediction::configured_policy(config).label()
+    );
+    println!();
     println!("Model outcomes:");
     println!("  Attempts: {}", report.model.attempts);
     println!(
@@ -65,6 +82,18 @@ pub fn run(config: &AppConfig) {
         replay::ZSH_P95_BUDGET_MS
     );
     println!("Privacy: aggregate metrics only; no command text printed or uploaded.");
+}
+
+fn print_policy(policy: PolicyKind, metrics: &Metrics) {
+    println!(
+        "  {:<21} samples={} coverage={:.1}% top-1={:.1}% p50={:.3}ms p95={:.3}ms",
+        policy.label(),
+        metrics.samples,
+        metrics.coverage_percent(),
+        metrics.top1_percent(),
+        metrics.p50_ms(),
+        metrics.p95_ms()
+    );
 }
 
 fn print_summary(metrics: &Metrics) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub events: EventsConfig,
     #[serde(default)]
+    pub prediction: PredictionConfig,
+    #[serde(default)]
     pub privacy: PrivacyConfig,
 }
 
@@ -52,6 +54,12 @@ pub struct EventsConfig {
     pub retention: usize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictionConfig {
+    #[serde(default = "default_prediction_policy")]
+    pub policy: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PrivacyConfig {
     #[serde(default)]
@@ -74,6 +82,10 @@ fn default_channel() -> String {
 
 fn default_event_retention() -> usize {
     10_000
+}
+
+fn default_prediction_policy() -> String {
+    "contextual".to_string()
 }
 
 fn default_api_key_env() -> String {
@@ -113,6 +125,14 @@ impl Default for EventsConfig {
     fn default() -> Self {
         Self {
             retention: default_event_retention(),
+        }
+    }
+}
+
+impl Default for PredictionConfig {
+    fn default() -> Self {
+        Self {
+            policy: default_prediction_policy(),
         }
     }
 }
@@ -174,6 +194,7 @@ impl AppConfig {
             "llm.model" => Some(self.llm.model.clone()),
             "llm.prompt" => Some(self.llm.prompt.clone()),
             "events.retention" => Some(self.events.retention.to_string()),
+            "prediction.policy" => Some(self.prediction.policy.clone()),
             "privacy.excluded_literals" => Some(format!(
                 "[{}]",
                 vec!["<redacted>"; self.privacy.excluded_literals.len()].join(", ")
@@ -236,6 +257,14 @@ impl AppConfig {
                 }
                 self.events.retention = retention;
             }
+            "prediction.policy" => {
+                if !matches!(value, "v0.4-baseline" | "contextual") {
+                    return Err(
+                        "Invalid prediction policy. Valid: v0.4-baseline, contextual".to_string(),
+                    );
+                }
+                self.prediction.policy = value.to_string();
+            }
             "privacy.excluded_literals" => {
                 self.privacy.excluded_literals = parse_list(value);
             }
@@ -289,5 +318,10 @@ mod tests {
         assert!(config.set_value("update.channel", "pip").is_ok());
         assert!(config.set_value("update.channel", "aur").is_err());
         assert!(config.set_value("update.channel", "binary").is_err());
+    }
+
+    #[test]
+    fn contextual_policy_is_the_default_after_passing_the_promotion_gate() {
+        assert_eq!(AppConfig::default().prediction.policy, "contextual");
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -300,22 +300,10 @@ pub fn predict_after(
     config: &AppConfig,
 ) -> Option<prediction::Prediction> {
     let events = load_stored_events(&event_store_path());
-    let commands: Vec<_> = events
-        .iter()
-        .filter_map(|event| match event {
-            StoredEvent::Command(command) => Some(command),
-            StoredEvent::Suggestion(_) => None,
-        })
-        .collect();
-    let suggestions: Vec<_> = events
-        .iter()
-        .filter_map(|event| match event {
-            StoredEvent::Command(_) => None,
-            StoredEvent::Suggestion(suggestion) => Some(suggestion),
-        })
-        .collect();
+    let memory = Memory::from_stored(&events);
     let stored_current = event_id.and_then(|event_id| {
-        commands
+        memory
+            .commands
             .iter()
             .copied()
             .find(|event| event.id == event_id && event.command.trim() == command.trim())
@@ -342,10 +330,7 @@ pub fn predict_after(
     prediction::predict(
         prediction::configured_policy(config),
         current,
-        &Memory {
-            commands: &commands,
-            suggestions: &suggestions,
-        },
+        &memory,
         config,
     )
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,7 +5,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 use crate::config::AppConfig;
-use crate::predict::{is_ignored_command, main_cmd};
+use crate::prediction::{self, Memory};
 use crate::privacy;
 
 pub const SCHEMA_VERSION: u8 = 1;
@@ -16,6 +16,10 @@ pub struct CommandEvent {
     pub id: String,
     pub command: String,
     pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     pub started_at_ms: Option<i64>,
     pub duration_ms: Option<u64>,
     pub exit_code: Option<i32>,
@@ -84,14 +88,6 @@ impl SuggestionOutcome {
             _ => Err(format!("Unknown suggestion outcome: {value}")),
         }
     }
-}
-
-#[derive(Debug, Default)]
-struct CandidateScore {
-    result_matches: usize,
-    evidence: usize,
-    directory_matches: usize,
-    latest_index: usize,
 }
 
 #[derive(Debug, Default, PartialEq)]
@@ -181,7 +177,49 @@ fn validate_command(event: &CommandEvent, config: &AppConfig) -> Result<(), Stri
     if let Some(reason) = privacy::rejection_reason(&event.command, config) {
         return Err(format!("Refusing to store sensitive command: {reason}"));
     }
+    if event
+        .repository
+        .iter()
+        .chain(event.branch.iter())
+        .any(|value| value.chars().any(char::is_control))
+    {
+        return Err("Refusing to store repository context with control characters".to_string());
+    }
     Ok(())
+}
+
+pub fn discover_git_context(cwd: &str) -> (Option<String>, Option<String>) {
+    let mut directory = std::path::Path::new(cwd).canonicalize().ok();
+    while let Some(current) = directory {
+        let dot_git = current.join(".git");
+        if dot_git.exists() {
+            let git_dir = if dot_git.is_dir() {
+                dot_git
+            } else {
+                let contents = fs::read_to_string(&dot_git).ok();
+                let path = contents
+                    .as_deref()
+                    .and_then(|value| value.trim().strip_prefix("gitdir:"))
+                    .map(str::trim)
+                    .map(std::path::PathBuf::from);
+                match path {
+                    Some(path) if path.is_absolute() => path,
+                    Some(path) => current.join(path),
+                    None => return (None, None),
+                }
+            };
+            let branch = fs::read_to_string(git_dir.join("HEAD"))
+                .ok()
+                .and_then(|head| {
+                    head.trim()
+                        .strip_prefix("ref: refs/heads/")
+                        .map(str::to_string)
+                });
+            return (Some(current.to_string_lossy().into_owned()), branch);
+        }
+        directory = current.parent().map(std::path::Path::to_path_buf);
+    }
+    (None, None)
 }
 
 pub fn record_suggestion(event: SuggestionEvent, config: &AppConfig) -> Result<(), String> {
@@ -257,60 +295,59 @@ pub fn clear() -> Result<(), String> {
 pub fn predict_after(
     command: &str,
     exit_code: i32,
+    event_id: Option<&str>,
     cwd: Option<&str>,
     config: &AppConfig,
-) -> Option<String> {
-    let events = load_command_events();
-    let mut candidates = std::collections::HashMap::<String, CandidateScore>::new();
-    let successors: std::collections::HashMap<&str, &CommandEvent> = events
+) -> Option<prediction::Prediction> {
+    let events = load_stored_events(&event_store_path());
+    let commands: Vec<_> = events
         .iter()
-        .filter_map(|event| {
-            event
-                .previous_event_id
-                .as_deref()
-                .map(|previous_id| (previous_id, event))
+        .filter_map(|event| match event {
+            StoredEvent::Command(command) => Some(command),
+            StoredEvent::Suggestion(_) => None,
         })
         .collect();
-    let wanted_success = exit_code == 0;
-
-    for (index, event) in events.iter().enumerate() {
-        if event.command.trim() != command.trim()
-            || event
-                .exit_code
-                .is_some_and(|code| (code == 0) != wanted_success)
-        {
-            continue;
-        }
-
-        let Some(next) = successors.get(event.id.as_str()) else {
-            continue;
-        };
-        if next.command.chars().any(char::is_control)
-            || privacy::rejection_reason(&next.command, config).is_some()
-            || is_ignored_command(main_cmd(&next.command), config)
-        {
-            continue;
-        }
-
-        let score = candidates.entry(next.command.clone()).or_default();
-        score.result_matches += usize::from(event.exit_code.is_some());
-        score.evidence += 1;
-        score.directory_matches +=
-            usize::from(cwd.is_some_and(|cwd| Some(cwd) == event.cwd.as_deref()));
-        score.latest_index = index;
-    }
-
-    let mut ranked: Vec<_> = candidates.into_iter().collect();
-    ranked.sort_by(|(command_a, score_a), (command_b, score_b)| {
-        score_b
-            .result_matches
-            .cmp(&score_a.result_matches)
-            .then_with(|| score_b.directory_matches.cmp(&score_a.directory_matches))
-            .then_with(|| score_b.evidence.cmp(&score_a.evidence))
-            .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
-            .then_with(|| command_a.cmp(command_b))
+    let suggestions: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            StoredEvent::Command(_) => None,
+            StoredEvent::Suggestion(suggestion) => Some(suggestion),
+        })
+        .collect();
+    let stored_current = event_id.and_then(|event_id| {
+        commands
+            .iter()
+            .copied()
+            .find(|event| event.id == event_id && event.command.trim() == command.trim())
     });
-    ranked.into_iter().next().map(|(command, _)| command)
+    let (repository, branch) = if stored_current.is_none() {
+        cwd.map(discover_git_context).unwrap_or((None, None))
+    } else {
+        (None, None)
+    };
+    let synthetic_current = CommandEvent {
+        schema_version: SCHEMA_VERSION,
+        id: String::new(),
+        command: command.to_string(),
+        cwd: cwd.map(str::to_string),
+        repository,
+        branch,
+        started_at_ms: None,
+        duration_ms: None,
+        exit_code: Some(exit_code),
+        shell: String::new(),
+        previous_event_id: None,
+    };
+    let current = stored_current.unwrap_or(&synthetic_current);
+    prediction::predict(
+        prediction::configured_policy(config),
+        current,
+        &Memory {
+            commands: &commands,
+            suggestions: &suggestions,
+        },
+        config,
+    )
 }
 
 fn load_command_events() -> Vec<CommandEvent> {

--- a/src/history_import.rs
+++ b/src/history_import.rs
@@ -91,6 +91,8 @@ fn prepare_zsh(
                         id: id.clone(),
                         command: entry.command.to_string(),
                         cwd: None,
+                        repository: None,
+                        branch: None,
                         started_at_ms: entry.started_at_ms,
                         duration_ms: entry.duration_ms,
                         exit_code: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod events;
 mod history_import;
 mod learn;
 mod predict;
+mod prediction;
 mod privacy;
 mod replay;
 mod report;
@@ -53,8 +54,10 @@ fn main() {
         }
         Some(Commands::Now {
             raw,
+            include_source,
             after,
             exit_code,
+            event_id,
             cwd,
         }) => {
             require_known_shell(&shell);
@@ -67,7 +70,9 @@ fn main() {
                 commands::now::InvocationContext {
                     after: after.as_deref(),
                     exit_code,
+                    event_id: event_id.as_deref(),
                     cwd: cwd.as_deref(),
+                    include_source,
                 },
             );
         }

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -1,0 +1,609 @@
+use std::collections::HashMap;
+
+use chrono::{Datelike, TimeZone, Timelike, Utc};
+
+use crate::config::AppConfig;
+use crate::events::{CommandEvent, SuggestionEvent, SuggestionOutcome};
+use crate::predict::{is_ignored_command, main_cmd};
+use crate::privacy;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyKind {
+    V04Baseline,
+    Contextual,
+}
+
+impl PolicyKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::V04Baseline => "v0.4-baseline",
+            Self::Contextual => "contextual-policy",
+        }
+    }
+
+    pub fn event_source(self) -> &'static str {
+        match self {
+            Self::V04Baseline => "deterministic-history",
+            Self::Contextual => "contextual-policy",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Prediction {
+    pub command: String,
+    pub policy: PolicyKind,
+    pub candidate_source: &'static str,
+    pub signal_groups: Vec<&'static str>,
+}
+
+pub struct Memory<'a> {
+    pub commands: &'a [&'a CommandEvent],
+    pub suggestions: &'a [&'a SuggestionEvent],
+}
+
+struct Candidate<'a> {
+    command: &'a str,
+    source: &'static str,
+    observations: Vec<Observation<'a>>,
+}
+
+struct Observation<'a> {
+    event: &'a CommandEvent,
+    previous: Option<&'a CommandEvent>,
+    index: usize,
+}
+
+trait CandidateSource {
+    fn label(&self) -> &'static str;
+
+    fn retrieve<'a>(
+        &self,
+        current: &CommandEvent,
+        memory: &Memory<'a>,
+        config: &AppConfig,
+    ) -> Vec<Candidate<'a>>;
+}
+
+trait Ranker {
+    fn rank(
+        &self,
+        current: &CommandEvent,
+        candidates: Vec<Candidate<'_>>,
+        memory: &Memory<'_>,
+    ) -> Option<Prediction>;
+}
+
+struct TransitionHistorySource;
+
+impl CandidateSource for TransitionHistorySource {
+    fn label(&self) -> &'static str {
+        "event-history"
+    }
+
+    fn retrieve<'a>(
+        &self,
+        current: &CommandEvent,
+        memory: &Memory<'a>,
+        config: &AppConfig,
+    ) -> Vec<Candidate<'a>> {
+        let by_id: HashMap<&str, &CommandEvent> = memory
+            .commands
+            .iter()
+            .map(|event| (event.id.as_str(), *event))
+            .collect();
+        let wanted_success = current.exit_code.map(|code| code == 0);
+        let mut candidates = HashMap::<&str, Candidate<'a>>::new();
+
+        for (index, next) in memory.commands.iter().copied().enumerate() {
+            let Some(previous) = next
+                .previous_event_id
+                .as_deref()
+                .and_then(|id| by_id.get(id).copied())
+            else {
+                continue;
+            };
+            if previous.command.trim() != current.command.trim()
+                || matches!(
+                    (previous.exit_code.map(|code| code == 0), wanted_success),
+                    (Some(observed), Some(wanted)) if observed != wanted
+                )
+                || next.command.chars().any(char::is_control)
+                || privacy::rejection_reason(&next.command, config).is_some()
+                || is_ignored_command(main_cmd(&next.command), config)
+            {
+                continue;
+            }
+
+            candidates
+                .entry(next.command.trim())
+                .or_insert_with(|| Candidate {
+                    command: next.command.trim(),
+                    source: self.label(),
+                    observations: Vec::new(),
+                })
+                .observations
+                .push(Observation {
+                    event: next,
+                    previous: Some(previous),
+                    index,
+                });
+        }
+
+        candidates.into_values().collect()
+    }
+}
+
+#[derive(Default)]
+struct CandidateScore {
+    result_matches: usize,
+    evidence: usize,
+    directory_matches: usize,
+    latest_index: usize,
+}
+
+struct V04Ranker;
+
+impl Ranker for V04Ranker {
+    fn rank(
+        &self,
+        current: &CommandEvent,
+        candidates: Vec<Candidate<'_>>,
+        _memory: &Memory<'_>,
+    ) -> Option<Prediction> {
+        let mut ranked: Vec<_> = candidates
+            .into_iter()
+            .map(|candidate| {
+                let score = candidate.observations.iter().fold(
+                    CandidateScore::default(),
+                    |mut score, observation| {
+                        score.result_matches += usize::from(
+                            observation
+                                .previous
+                                .is_some_and(|event| event.exit_code.is_some()),
+                        );
+                        score.evidence += 1;
+                        score.directory_matches += usize::from(
+                            current.cwd.is_some()
+                                && observation
+                                    .previous
+                                    .is_some_and(|event| event.cwd == current.cwd),
+                        );
+                        score.latest_index = score.latest_index.max(observation.index);
+                        score
+                    },
+                );
+                (candidate, score)
+            })
+            .collect();
+        ranked.sort_by(|(candidate_a, score_a), (candidate_b, score_b)| {
+            score_b
+                .result_matches
+                .cmp(&score_a.result_matches)
+                .then_with(|| score_b.directory_matches.cmp(&score_a.directory_matches))
+                .then_with(|| score_b.evidence.cmp(&score_a.evidence))
+                .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
+                .then_with(|| candidate_a.command.cmp(candidate_b.command))
+        });
+        ranked.into_iter().next().map(|(candidate, _)| {
+            let mut signal_groups = Vec::new();
+            if candidate.observations.iter().any(|observation| {
+                observation
+                    .previous
+                    .is_some_and(|event| event.exit_code.is_some())
+            }) {
+                signal_groups.push("result");
+            }
+            if current.cwd.is_some()
+                && candidate.observations.iter().any(|observation| {
+                    observation
+                        .previous
+                        .is_some_and(|event| event.cwd.is_some())
+                })
+            {
+                signal_groups.push("directory");
+            }
+            signal_groups.extend(["frequency", "recency"]);
+            Prediction {
+                command: candidate.command.to_string(),
+                policy: PolicyKind::V04Baseline,
+                candidate_source: candidate.source,
+                signal_groups,
+            }
+        })
+    }
+}
+
+struct FullHistorySource;
+
+impl CandidateSource for FullHistorySource {
+    fn label(&self) -> &'static str {
+        "event-history"
+    }
+
+    fn retrieve<'a>(
+        &self,
+        current: &CommandEvent,
+        memory: &Memory<'a>,
+        config: &AppConfig,
+    ) -> Vec<Candidate<'a>> {
+        let by_id: HashMap<&str, &CommandEvent> = memory
+            .commands
+            .iter()
+            .map(|event| (event.id.as_str(), *event))
+            .collect();
+        let mut candidates = HashMap::<&str, Candidate<'a>>::new();
+
+        for (index, event) in memory.commands.iter().copied().enumerate() {
+            if event.id == current.id
+                || event.command.chars().any(char::is_control)
+                || privacy::rejection_reason(&event.command, config).is_some()
+                || is_ignored_command(main_cmd(&event.command), config)
+            {
+                continue;
+            }
+            let previous = event
+                .previous_event_id
+                .as_deref()
+                .and_then(|id| by_id.get(id).copied());
+            candidates
+                .entry(event.command.trim())
+                .or_insert_with(|| Candidate {
+                    command: event.command.trim(),
+                    source: self.label(),
+                    observations: Vec::new(),
+                })
+                .observations
+                .push(Observation {
+                    event,
+                    previous,
+                    index,
+                });
+        }
+
+        candidates.into_values().collect()
+    }
+}
+
+#[derive(Default)]
+struct ContextualScore {
+    total: f64,
+    second_order_matches: usize,
+    second_order_known: usize,
+    directory_matches: usize,
+    directory_known: usize,
+    repository_matches: usize,
+    repository_known: usize,
+    branch_matches: usize,
+    branch_known: usize,
+    hour_matches: usize,
+    hour_known: usize,
+    weekday_matches: usize,
+    weekday_known: usize,
+    result_matches: usize,
+    result_known: usize,
+    duration_matches: usize,
+    duration_known: usize,
+    first_order_matches: usize,
+    first_order_known: usize,
+    feedback: usize,
+    evidence: usize,
+    latest_index: usize,
+}
+
+struct ContextualRanker;
+
+impl Ranker for ContextualRanker {
+    fn rank(
+        &self,
+        current: &CommandEvent,
+        mut candidates: Vec<Candidate<'_>>,
+        memory: &Memory<'_>,
+    ) -> Option<Prediction> {
+        let by_id: HashMap<&str, &CommandEvent> = memory
+            .commands
+            .iter()
+            .map(|event| (event.id.as_str(), *event))
+            .collect();
+        let current_predecessor_command = current
+            .previous_event_id
+            .as_deref()
+            .and_then(|id| by_id.get(id).copied())
+            .map(|event| event.command.trim());
+        let has_first_order_evidence = candidates.iter().any(|candidate| {
+            candidate.observations.iter().any(|observation| {
+                observation
+                    .previous
+                    .is_some_and(|event| event.command.trim() == current.command.trim())
+            })
+        });
+        if has_first_order_evidence {
+            candidates.retain(|candidate| {
+                candidate.observations.iter().any(|observation| {
+                    observation
+                        .previous
+                        .is_some_and(|event| event.command.trim() == current.command.trim())
+                })
+            });
+        } else {
+            candidates.retain(|candidate| candidate.command != current.command.trim());
+        }
+
+        let wanted_success = current.exit_code.map(|code| code == 0);
+        let candidate_count = candidates.len();
+        let total_evidence: usize = candidates
+            .iter()
+            .map(|candidate| candidate.observations.len())
+            .sum();
+        let max_index = memory.commands.len().saturating_sub(1).max(1);
+        let mut ranked: Vec<_> = candidates
+            .into_iter()
+            .map(|candidate| {
+                let score = candidate.observations.iter().fold(
+                    ContextualScore::default(),
+                    |mut score, observation| {
+                        score.second_order_known += usize::from(
+                            current_predecessor_command.is_some()
+                                && observation
+                                    .previous
+                                    .and_then(|event| event.previous_event_id.as_deref())
+                                    .and_then(|id| by_id.get(id).copied())
+                                    .is_some(),
+                        );
+                        score.second_order_matches += usize::from(matches!(
+                            (
+                                current_predecessor_command,
+                                observation
+                                    .previous
+                                    .and_then(|event| event.previous_event_id.as_deref())
+                                    .and_then(|id| by_id.get(id).copied())
+                                    .map(|event| event.command.trim())
+                            ),
+                            (Some(current), Some(observed)) if current == observed
+                        ));
+                        score.directory_known +=
+                            usize::from(current.cwd.is_some() && observation.event.cwd.is_some());
+                        score.directory_matches += usize::from(
+                            current.cwd.is_some() && observation.event.cwd == current.cwd,
+                        );
+                        score.repository_known += usize::from(
+                            current.repository.is_some() && observation.event.repository.is_some(),
+                        );
+                        score.repository_matches += usize::from(
+                            current.repository.is_some()
+                                && observation.event.repository == current.repository,
+                        );
+                        score.branch_known += usize::from(
+                            current.branch.is_some() && observation.event.branch.is_some(),
+                        );
+                        score.branch_matches += usize::from(
+                            current.branch.is_some() && observation.event.branch == current.branch,
+                        );
+                        score.hour_known += usize::from(
+                            current.started_at_ms.and_then(hour_bucket).is_some()
+                                && observation
+                                    .event
+                                    .started_at_ms
+                                    .and_then(hour_bucket)
+                                    .is_some(),
+                        );
+                        score.hour_matches += usize::from(matches!(
+                            (
+                                current.started_at_ms.and_then(hour_bucket),
+                                observation.event.started_at_ms.and_then(hour_bucket)
+                            ),
+                            (Some(current), Some(observed)) if current == observed
+                        ));
+                        score.weekday_known += usize::from(
+                            current.started_at_ms.and_then(weekday).is_some()
+                                && observation.event.started_at_ms.and_then(weekday).is_some(),
+                        );
+                        score.weekday_matches += usize::from(matches!(
+                            (
+                                current.started_at_ms.and_then(weekday),
+                                observation.event.started_at_ms.and_then(weekday)
+                            ),
+                            (Some(current), Some(observed)) if current == observed
+                        ));
+                        score.result_known += usize::from(
+                            wanted_success.is_some()
+                                && observation
+                                    .previous
+                                    .is_some_and(|event| event.exit_code.is_some()),
+                        );
+                        score.result_matches +=
+                            usize::from(observation.previous.is_some_and(|event| {
+                                matches!(
+                                    (event.exit_code.map(|code| code == 0), wanted_success),
+                                    (Some(observed), Some(wanted)) if observed == wanted
+                                )
+                            }));
+                        score.duration_known += usize::from(
+                            current.duration_ms.is_some()
+                                && observation
+                                    .previous
+                                    .is_some_and(|event| event.duration_ms.is_some()),
+                        );
+                        score.duration_matches += usize::from(matches!(
+                            (
+                                current.duration_ms.map(duration_bucket),
+                                observation
+                                    .previous
+                                    .and_then(|event| event.duration_ms)
+                                    .map(duration_bucket)
+                            ),
+                            (Some(current), Some(observed)) if current == observed
+                        ));
+                        score.first_order_known += usize::from(observation.previous.is_some());
+                        score.first_order_matches +=
+                            usize::from(observation.previous.is_some_and(|event| {
+                                event.command.trim() == current.command.trim()
+                            }));
+                        score.evidence += 1;
+                        score.latest_index = score.latest_index.max(observation.index);
+                        score
+                    },
+                );
+                let feedback = memory
+                    .suggestions
+                    .iter()
+                    .filter(|event| event.command.trim() == candidate.command)
+                    .map(|event| match event.outcome {
+                        SuggestionOutcome::Accepted => 2,
+                        SuggestionOutcome::Executed => 4,
+                        SuggestionOutcome::Shown | SuggestionOutcome::Dismissed => 0,
+                    })
+                    .sum();
+                let mut score = ContextualScore { feedback, ..score };
+                score.total = smoothed_prior(score.evidence, total_evidence, candidate_count)
+                    + 2.0 * smoothed_match(score.first_order_matches, score.first_order_known, 2)
+                    + 2.5 * smoothed_match(score.second_order_matches, score.second_order_known, 2)
+                    + 1.5 * smoothed_match(score.directory_matches, score.directory_known, 2)
+                    + 1.25 * smoothed_match(score.repository_matches, score.repository_known, 2)
+                    + 1.25 * smoothed_match(score.branch_matches, score.branch_known, 2)
+                    + 0.75 * smoothed_match(score.hour_matches, score.hour_known, 6)
+                    + 0.75 * smoothed_match(score.weekday_matches, score.weekday_known, 7)
+                    + 1.5 * smoothed_match(score.result_matches, score.result_known, 2)
+                    + 0.75 * smoothed_match(score.duration_matches, score.duration_known, 4)
+                    + 1.5 * (score.feedback as f64).ln_1p()
+                    + 0.25 * score.latest_index as f64 / max_index as f64;
+                (candidate, score)
+            })
+            .collect();
+        ranked.sort_by(|(candidate_a, score_a), (candidate_b, score_b)| {
+            score_b
+                .total
+                .total_cmp(&score_a.total)
+                .then_with(|| score_b.evidence.cmp(&score_a.evidence))
+                .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
+                .then_with(|| candidate_a.command.cmp(candidate_b.command))
+        });
+        ranked.into_iter().next().map(|(candidate, score)| {
+            let mut signal_groups = Vec::new();
+            if score.first_order_matches > 0 || score.second_order_matches > 0 {
+                signal_groups.push("transition");
+            }
+            if current.cwd.is_some()
+                && candidate
+                    .observations
+                    .iter()
+                    .any(|observation| observation.event.cwd.is_some())
+            {
+                signal_groups.push("directory");
+            }
+            if current.repository.is_some()
+                && candidate
+                    .observations
+                    .iter()
+                    .any(|observation| observation.event.repository.is_some())
+            {
+                signal_groups.push("repository");
+            }
+            if current.branch.is_some()
+                && candidate
+                    .observations
+                    .iter()
+                    .any(|observation| observation.event.branch.is_some())
+            {
+                signal_groups.push("branch");
+            }
+            if current.started_at_ms.is_some()
+                && candidate
+                    .observations
+                    .iter()
+                    .any(|observation| observation.event.started_at_ms.is_some())
+            {
+                signal_groups.push("time");
+            }
+            if current.exit_code.is_some()
+                && candidate.observations.iter().any(|observation| {
+                    observation
+                        .previous
+                        .is_some_and(|event| event.exit_code.is_some())
+                })
+            {
+                signal_groups.push("result");
+            }
+            if current.duration_ms.is_some()
+                && candidate.observations.iter().any(|observation| {
+                    observation
+                        .previous
+                        .is_some_and(|event| event.duration_ms.is_some())
+                })
+            {
+                signal_groups.push("duration");
+            }
+            if score.feedback > 0 {
+                signal_groups.push("feedback");
+            }
+            signal_groups.extend(["frequency", "recency"]);
+            Prediction {
+                command: candidate.command.to_string(),
+                policy: PolicyKind::Contextual,
+                candidate_source: candidate.source,
+                signal_groups,
+            }
+        })
+    }
+}
+
+fn hour_bucket(timestamp_ms: i64) -> Option<u32> {
+    Utc.timestamp_millis_opt(timestamp_ms)
+        .single()
+        .map(|timestamp| timestamp.hour() / 4)
+}
+
+fn weekday(timestamp_ms: i64) -> Option<u32> {
+    Utc.timestamp_millis_opt(timestamp_ms)
+        .single()
+        .map(|timestamp| timestamp.weekday().num_days_from_monday())
+}
+
+fn duration_bucket(duration_ms: u64) -> u8 {
+    match duration_ms {
+        0..=999 => 0,
+        1_000..=9_999 => 1,
+        10_000..=59_999 => 2,
+        _ => 3,
+    }
+}
+
+fn smoothed_prior(evidence: usize, total_evidence: usize, candidate_count: usize) -> f64 {
+    if candidate_count == 0 {
+        return 0.0;
+    }
+    ((evidence + 1) as f64 / (total_evidence + candidate_count) as f64).ln()
+}
+
+fn smoothed_match(matches: usize, known: usize, categories: usize) -> f64 {
+    if known == 0 {
+        return 0.0;
+    }
+    (((matches + 1) * categories) as f64 / (known + categories) as f64).ln()
+}
+
+pub fn predict(
+    policy: PolicyKind,
+    current: &CommandEvent,
+    memory: &Memory<'_>,
+    config: &AppConfig,
+) -> Option<Prediction> {
+    match policy {
+        PolicyKind::V04Baseline => {
+            let candidates = TransitionHistorySource.retrieve(current, memory, config);
+            V04Ranker.rank(current, candidates, memory)
+        }
+        PolicyKind::Contextual => {
+            let candidates = FullHistorySource.retrieve(current, memory, config);
+            ContextualRanker.rank(current, candidates, memory)
+        }
+    }
+}
+
+pub fn configured_policy(config: &AppConfig) -> PolicyKind {
+    if config.prediction.policy == "contextual" {
+        PolicyKind::Contextual
+    } else {
+        PolicyKind::V04Baseline
+    }
+}

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::{Datelike, TimeZone, Timelike, Utc};
 
 use crate::config::AppConfig;
-use crate::events::{CommandEvent, SuggestionEvent, SuggestionOutcome};
+use crate::events::{CommandEvent, StoredEvent, SuggestionEvent, SuggestionOutcome};
 use crate::predict::{is_ignored_command, main_cmd};
 use crate::privacy;
 
@@ -37,9 +37,27 @@ pub struct Prediction {
     pub signal_groups: Vec<&'static str>,
 }
 
+#[derive(Default)]
 pub struct Memory<'a> {
-    pub commands: &'a [&'a CommandEvent],
-    pub suggestions: &'a [&'a SuggestionEvent],
+    pub commands: Vec<&'a CommandEvent>,
+    pub suggestions: Vec<&'a SuggestionEvent>,
+}
+
+impl<'a> Memory<'a> {
+    pub(crate) fn from_stored(events: &'a [StoredEvent]) -> Self {
+        let mut memory = Self::default();
+        for event in events {
+            memory.push(event);
+        }
+        memory
+    }
+
+    pub(crate) fn push(&mut self, event: &'a StoredEvent) {
+        match event {
+            StoredEvent::Command(command) => self.commands.push(command),
+            StoredEvent::Suggestion(suggestion) => self.suggestions.push(suggestion),
+        }
+    }
 }
 
 struct Candidate<'a> {
@@ -185,33 +203,35 @@ impl Ranker for V04Ranker {
                 .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
                 .then_with(|| candidate_a.command.cmp(candidate_b.command))
         });
-        ranked.into_iter().next().map(|(candidate, _)| {
-            let mut signal_groups = Vec::new();
-            if candidate.observations.iter().any(|observation| {
-                observation
-                    .previous
-                    .is_some_and(|event| event.exit_code.is_some())
-            }) {
-                signal_groups.push("result");
-            }
-            if current.cwd.is_some()
-                && candidate.observations.iter().any(|observation| {
-                    observation
-                        .previous
-                        .is_some_and(|event| event.cwd.is_some())
-                })
-            {
-                signal_groups.push("directory");
-            }
-            signal_groups.extend(["frequency", "recency"]);
-            Prediction {
-                command: candidate.command.to_string(),
-                policy: PolicyKind::V04Baseline,
-                candidate_source: candidate.source,
-                signal_groups,
-            }
+        ranked.into_iter().next().map(|(candidate, _)| Prediction {
+            command: candidate.command.to_string(),
+            policy: PolicyKind::V04Baseline,
+            candidate_source: candidate.source,
+            signal_groups: v04_signal_groups(current, &candidate),
         })
     }
+}
+
+fn v04_signal_groups(current: &CommandEvent, candidate: &Candidate<'_>) -> Vec<&'static str> {
+    let mut groups = Vec::new();
+    if candidate.observations.iter().any(|observation| {
+        observation
+            .previous
+            .is_some_and(|event| event.exit_code.is_some())
+    }) {
+        groups.push("result");
+    }
+    if current.cwd.is_some()
+        && candidate.observations.iter().any(|observation| {
+            observation
+                .previous
+                .is_some_and(|event| event.cwd.is_some())
+        })
+    {
+        groups.push("directory");
+    }
+    groups.extend(["frequency", "recency"]);
+    groups
 }
 
 struct FullHistorySource;
@@ -478,73 +498,82 @@ impl Ranker for ContextualRanker {
                 .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
                 .then_with(|| candidate_a.command.cmp(candidate_b.command))
         });
-        ranked.into_iter().next().map(|(candidate, score)| {
-            let mut signal_groups = Vec::new();
-            if score.first_order_matches > 0 || score.second_order_matches > 0 {
-                signal_groups.push("transition");
-            }
-            if current.cwd.is_some()
-                && candidate
-                    .observations
-                    .iter()
-                    .any(|observation| observation.event.cwd.is_some())
-            {
-                signal_groups.push("directory");
-            }
-            if current.repository.is_some()
-                && candidate
-                    .observations
-                    .iter()
-                    .any(|observation| observation.event.repository.is_some())
-            {
-                signal_groups.push("repository");
-            }
-            if current.branch.is_some()
-                && candidate
-                    .observations
-                    .iter()
-                    .any(|observation| observation.event.branch.is_some())
-            {
-                signal_groups.push("branch");
-            }
-            if current.started_at_ms.is_some()
-                && candidate
-                    .observations
-                    .iter()
-                    .any(|observation| observation.event.started_at_ms.is_some())
-            {
-                signal_groups.push("time");
-            }
-            if current.exit_code.is_some()
-                && candidate.observations.iter().any(|observation| {
-                    observation
-                        .previous
-                        .is_some_and(|event| event.exit_code.is_some())
-                })
-            {
-                signal_groups.push("result");
-            }
-            if current.duration_ms.is_some()
-                && candidate.observations.iter().any(|observation| {
-                    observation
-                        .previous
-                        .is_some_and(|event| event.duration_ms.is_some())
-                })
-            {
-                signal_groups.push("duration");
-            }
-            if score.feedback > 0 {
-                signal_groups.push("feedback");
-            }
-            signal_groups.extend(["frequency", "recency"]);
-            Prediction {
+        ranked
+            .into_iter()
+            .next()
+            .map(|(candidate, score)| Prediction {
                 command: candidate.command.to_string(),
                 policy: PolicyKind::Contextual,
                 candidate_source: candidate.source,
-                signal_groups,
-            }
-        })
+                signal_groups: contextual_signal_groups(current, &candidate, &score),
+            })
     }
+}
+
+fn contextual_signal_groups(
+    current: &CommandEvent,
+    candidate: &Candidate<'_>,
+    score: &ContextualScore,
+) -> Vec<&'static str> {
+    let mut groups = Vec::new();
+    if score.first_order_matches > 0 || score.second_order_matches > 0 {
+        groups.push("transition");
+    }
+    if current.cwd.is_some()
+        && candidate
+            .observations
+            .iter()
+            .any(|observation| observation.event.cwd.is_some())
+    {
+        groups.push("directory");
+    }
+    if current.repository.is_some()
+        && candidate
+            .observations
+            .iter()
+            .any(|observation| observation.event.repository.is_some())
+    {
+        groups.push("repository");
+    }
+    if current.branch.is_some()
+        && candidate
+            .observations
+            .iter()
+            .any(|observation| observation.event.branch.is_some())
+    {
+        groups.push("branch");
+    }
+    if current.started_at_ms.is_some()
+        && candidate
+            .observations
+            .iter()
+            .any(|observation| observation.event.started_at_ms.is_some())
+    {
+        groups.push("time");
+    }
+    if current.exit_code.is_some()
+        && candidate.observations.iter().any(|observation| {
+            observation
+                .previous
+                .is_some_and(|event| event.exit_code.is_some())
+        })
+    {
+        groups.push("result");
+    }
+    if current.duration_ms.is_some()
+        && candidate.observations.iter().any(|observation| {
+            observation
+                .previous
+                .is_some_and(|event| event.duration_ms.is_some())
+        })
+    {
+        groups.push("duration");
+    }
+    if score.feedback > 0 {
+        groups.push("feedback");
+    }
+    groups.extend(["frequency", "recency"]);
+    groups
 }
 
 fn hour_bucket(timestamp_ms: i64) -> Option<u32> {

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -6,6 +6,7 @@ use crate::events::{
     self, CommandEvent, ModelOutcome, StoredEvent, SuggestionEvent, SuggestionOutcome,
 };
 use crate::predict::{is_ignored_command, main_cmd};
+use crate::prediction::{self, Memory, PolicyKind};
 use crate::privacy;
 
 pub const ZSH_P95_BUDGET_MS: f64 = 20.0;
@@ -105,6 +106,8 @@ impl ModelMetrics {
 #[derive(Debug, Default)]
 pub struct ReplayReport {
     pub overall: Metrics,
+    pub baseline: Metrics,
+    pub contextual: Metrics,
     by_trigger: HashMap<Trigger, Metrics>,
     by_source: HashMap<String, Metrics>,
     pub model: ModelMetrics,
@@ -124,21 +127,12 @@ impl ReplayReport {
         sources.sort_by_key(|(source, _)| *source);
         sources
     }
-}
 
-#[derive(Debug)]
-struct Transition<'a> {
-    previous: &'a CommandEvent,
-    next: &'a CommandEvent,
-    index: usize,
-}
-
-#[derive(Debug, Default)]
-struct CandidateScore {
-    result_matches: usize,
-    evidence: usize,
-    directory_matches: usize,
-    latest_index: usize,
+    pub fn contextual_promotion_passes(&self) -> bool {
+        self.contextual.top1_matches > self.baseline.top1_matches
+            && self.contextual.covered >= self.baseline.covered
+            && self.contextual.p95_ms() <= ZSH_P95_BUDGET_MS
+    }
 }
 
 #[derive(Debug)]
@@ -150,7 +144,8 @@ struct RecordedSuggestion<'a> {
 pub fn run(config: &AppConfig) -> ReplayReport {
     let stored_events = events::replay_events();
     let mut seen = HashMap::<&str, &CommandEvent>::new();
-    let mut transitions = Vec::<Transition<'_>>::new();
+    let mut commands = Vec::<&CommandEvent>::new();
+    let mut suggestions = Vec::<&SuggestionEvent>::new();
     let mut pending = HashMap::<&str, Vec<RecordedSuggestion<'_>>>::new();
     let mut pending_manual = Vec::<RecordedSuggestion<'_>>::new();
     let mut report = ReplayReport::default();
@@ -167,26 +162,67 @@ pub fn run(config: &AppConfig) -> ReplayReport {
                 if let Some(previous_id) = command.previous_event_id.as_deref() {
                     if let Some(previous) = seen.get(previous_id).copied() {
                         if is_candidate(&command.command, config) {
+                            let memory = Memory {
+                                commands: &commands,
+                                suggestions: &suggestions,
+                            };
                             let started = Instant::now();
-                            let prediction = predict(previous, &transitions, config);
-                            let latency_ms = started.elapsed().as_secs_f64() * 1_000.0;
+                            let baseline = prediction::predict(
+                                PolicyKind::V04Baseline,
+                                previous,
+                                &memory,
+                                config,
+                            );
+                            let baseline_latency_ms = started.elapsed().as_secs_f64() * 1_000.0;
+                            let started = Instant::now();
+                            let contextual = prediction::predict(
+                                PolicyKind::Contextual,
+                                previous,
+                                &memory,
+                                config,
+                            );
+                            let contextual_latency_ms = started.elapsed().as_secs_f64() * 1_000.0;
                             let trigger = Trigger::from_exit_code(previous.exit_code);
 
                             report.overall.record(
-                                prediction.as_deref(),
+                                baseline
+                                    .as_ref()
+                                    .map(|prediction| prediction.command.as_str()),
                                 command.command.trim(),
-                                latency_ms,
+                                baseline_latency_ms,
+                            );
+                            report.baseline.record(
+                                baseline
+                                    .as_ref()
+                                    .map(|prediction| prediction.command.as_str()),
+                                command.command.trim(),
+                                baseline_latency_ms,
+                            );
+                            report.contextual.record(
+                                contextual
+                                    .as_ref()
+                                    .map(|prediction| prediction.command.as_str()),
+                                command.command.trim(),
+                                contextual_latency_ms,
                             );
                             report.by_trigger.entry(trigger).or_default().record(
-                                prediction.as_deref(),
+                                baseline
+                                    .as_ref()
+                                    .map(|prediction| prediction.command.as_str()),
                                 command.command.trim(),
-                                latency_ms,
+                                baseline_latency_ms,
                             );
                             report
                                 .by_source
                                 .entry("deterministic-history".to_string())
                                 .or_default()
-                                .record(prediction.as_deref(), command.command.trim(), latency_ms);
+                                .record(
+                                    baseline
+                                        .as_ref()
+                                        .map(|prediction| prediction.command.as_str()),
+                                    command.command.trim(),
+                                    baseline_latency_ms,
+                                );
                         }
 
                         if let Some(suggestions) = pending.remove(previous.id.as_str()) {
@@ -194,28 +230,24 @@ pub fn run(config: &AppConfig) -> ReplayReport {
                                 score_recorded(&mut report, suggestions, command);
                             }
                         }
-                        transitions.push(Transition {
-                            previous,
-                            next: command,
-                            index: transitions.len(),
-                        });
                     }
                 }
                 seen.insert(command.id.as_str(), command);
+                commands.push(command);
             }
-            StoredEvent::Suggestion(suggestion)
-                if suggestion.outcome == SuggestionOutcome::Shown
-                    && is_safe_suggestion(suggestion, config) =>
-            {
-                let recorded = RecordedSuggestion {
-                    source: canonical_source(&suggestion.candidate_source),
-                    event: suggestion,
-                };
-                if let Some(command_event_id) = suggestion.command_event_id.as_deref() {
-                    pending.entry(command_event_id).or_default().push(recorded);
-                } else {
-                    pending_manual.push(recorded);
+            StoredEvent::Suggestion(suggestion) if is_safe_suggestion(suggestion, config) => {
+                if suggestion.outcome == SuggestionOutcome::Shown {
+                    let recorded = RecordedSuggestion {
+                        source: canonical_source(&suggestion.candidate_source),
+                        event: suggestion,
+                    };
+                    if let Some(command_event_id) = suggestion.command_event_id.as_deref() {
+                        pending.entry(command_event_id).or_default().push(recorded);
+                    } else {
+                        pending_manual.push(recorded);
+                    }
                 }
+                suggestions.push(suggestion);
             }
             StoredEvent::Command(_) | StoredEvent::Suggestion(_) => {}
         }
@@ -274,55 +306,6 @@ fn canonical_source(source: &str) -> &'static str {
         "deterministic-fallback" => "deterministic-fallback",
         _ => "other",
     }
-}
-
-fn predict(
-    current: &CommandEvent,
-    transitions: &[Transition<'_>],
-    config: &AppConfig,
-) -> Option<String> {
-    let wanted_success = current.exit_code.map(|code| code == 0);
-    let mut candidates = HashMap::<&str, CandidateScore>::new();
-
-    for transition in transitions {
-        if transition.previous.command.trim() != current.command.trim()
-            || matches!(
-                (
-                    transition.previous.exit_code.map(|code| code == 0),
-                    wanted_success
-                ),
-                (Some(observed), Some(wanted)) if observed != wanted
-            )
-            || privacy::rejection_reason(&transition.next.command, config).is_some()
-            || is_ignored_command(main_cmd(&transition.next.command), config)
-        {
-            continue;
-        }
-
-        let score = candidates
-            .entry(transition.next.command.trim())
-            .or_default();
-        score.result_matches += usize::from(transition.previous.exit_code.is_some());
-        score.evidence += 1;
-        score.directory_matches +=
-            usize::from(current.cwd.is_some() && transition.previous.cwd == current.cwd);
-        score.latest_index = transition.index;
-    }
-
-    let mut ranked: Vec<_> = candidates.into_iter().collect();
-    ranked.sort_by(|(command_a, score_a), (command_b, score_b)| {
-        score_b
-            .result_matches
-            .cmp(&score_a.result_matches)
-            .then_with(|| score_b.directory_matches.cmp(&score_a.directory_matches))
-            .then_with(|| score_b.evidence.cmp(&score_a.evidence))
-            .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
-            .then_with(|| command_a.cmp(command_b))
-    });
-    ranked
-        .into_iter()
-        .next()
-        .map(|(command, _)| command.to_string())
 }
 
 fn percent(numerator: usize, denominator: usize) -> f64 {

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -144,8 +144,7 @@ struct RecordedSuggestion<'a> {
 pub fn run(config: &AppConfig) -> ReplayReport {
     let stored_events = events::replay_events();
     let mut seen = HashMap::<&str, &CommandEvent>::new();
-    let mut commands = Vec::<&CommandEvent>::new();
-    let mut suggestions = Vec::<&SuggestionEvent>::new();
+    let mut memory = Memory::default();
     let mut pending = HashMap::<&str, Vec<RecordedSuggestion<'_>>>::new();
     let mut pending_manual = Vec::<RecordedSuggestion<'_>>::new();
     let mut report = ReplayReport::default();
@@ -162,10 +161,6 @@ pub fn run(config: &AppConfig) -> ReplayReport {
                 if let Some(previous_id) = command.previous_event_id.as_deref() {
                     if let Some(previous) = seen.get(previous_id).copied() {
                         if is_candidate(&command.command, config) {
-                            let memory = Memory {
-                                commands: &commands,
-                                suggestions: &suggestions,
-                            };
                             let started = Instant::now();
                             let baseline = prediction::predict(
                                 PolicyKind::V04Baseline,
@@ -233,7 +228,7 @@ pub fn run(config: &AppConfig) -> ReplayReport {
                     }
                 }
                 seen.insert(command.id.as_str(), command);
-                commands.push(command);
+                memory.push(stored_event);
             }
             StoredEvent::Suggestion(suggestion) if is_safe_suggestion(suggestion, config) => {
                 if suggestion.outcome == SuggestionOutcome::Shown {
@@ -247,7 +242,7 @@ pub fn run(config: &AppConfig) -> ReplayReport {
                         pending_manual.push(recorded);
                     }
                 }
-                suggestions.push(suggestion);
+                memory.push(stored_event);
             }
             StoredEvent::Command(_) | StoredEvent::Suggestion(_) => {}
         }

--- a/src/shell/soon.zsh
+++ b/src/shell/soon.zsh
@@ -23,11 +23,13 @@ if [[ -o interactive ]]; then
   typeset -g _soon_suggestion_trigger=''
   typeset -g _soon_suggestion_event_id=''
   typeset -g _soon_suggestion_latency=''
+  typeset -g _soon_suggestion_source=''
   typeset -g _soon_accepted_command=''
   typeset -g _soon_accepted_id=''
   typeset -g _soon_accepted_trigger=''
   typeset -g _soon_accepted_event_id=''
   typeset -g _soon_accepted_latency=''
+  typeset -g _soon_accepted_source=''
   typeset -g _soon_previous_ctrl_f=${${(z)$(bindkey '^F' 2>/dev/null)}[-1]}
   [[ -n $_soon_previous_ctrl_f ]] || _soon_previous_ctrl_f='.forward-char'
 
@@ -73,10 +75,18 @@ if [[ -o interactive ]]; then
   function _soon_prediction_ready() {
     local fd=$1
     local line=''
+    local payload=''
 
     if IFS= read -r line <&$fd && [[ $line == *$'\t'* ]]; then
       SOON_LAST_LATENCY_MS=${line%%$'\t'*}
-      _soon_suggestion=${line#*$'\t'}
+      payload=${line#*$'\t'}
+      if [[ $payload == *$'\t'* ]]; then
+        _soon_suggestion_source=${payload%%$'\t'*}
+        _soon_suggestion=${payload#*$'\t'}
+      else
+        _soon_suggestion_source='deterministic-history'
+        _soon_suggestion=$payload
+      fi
       _soon_suggestion_id="${EPOCHREALTIME//./}-$$-$RANDOM"
       _soon_suggestion_trigger=$_soon_prediction_trigger
       _soon_suggestion_event_id=$_soon_prediction_event_id
@@ -85,6 +95,7 @@ if [[ -o interactive ]]; then
     else
       _soon_suggestion=''
       _soon_suggestion_id=''
+      _soon_suggestion_source=''
     fi
     zle -F $fd 2>/dev/null || true
     (( fd == _soon_fd )) && _soon_fd=-1
@@ -96,7 +107,7 @@ if [[ -o interactive ]]; then
     local outcome=$1
     [[ -n $_soon_suggestion_id && -n $_soon_suggestion ]] || return 0
 
-    _soon_emit_suggestion "$outcome" "$_soon_suggestion_id" "$_soon_suggestion_trigger" "$_soon_suggestion_event_id" "$_soon_suggestion_latency" "$_soon_suggestion"
+    _soon_emit_suggestion "$outcome" "$_soon_suggestion_id" "$_soon_suggestion_trigger" "$_soon_suggestion_event_id" "$_soon_suggestion_latency" "$_soon_suggestion_source" "$_soon_suggestion"
   }
 
   function _soon_emit_suggestion() {
@@ -105,13 +116,14 @@ if [[ -o interactive ]]; then
     local trigger=$3
     local command_event_id=$4
     local latency=$5
-    local command_text=$6
+    local candidate_source=$6
+    local command_text=$7
 
     local -a event_args=(
       events record-suggestion
       --id "$suggestion_id"
       --trigger "$trigger"
-      --candidate-source history
+      --candidate-source "$candidate_source"
       --command "$command_text"
       --outcome "$outcome"
       --latency-ms "$latency"
@@ -131,6 +143,7 @@ if [[ -o interactive ]]; then
     local started=$EPOCHREALTIME
     _soon_cancel_prediction
     _soon_suggestion=''
+    _soon_suggestion_source=''
 
     if [[ -n $after ]]; then
       if (( exit_status == 0 )); then
@@ -153,7 +166,7 @@ if [[ -o interactive ]]; then
         )
         [[ -n $previous_event_id ]] && record_args+=(--previous-id "$previous_event_id")
         command soon "${record_args[@]}" >/dev/null 2>&1
-        suggestion=$(command soon --shell zsh --ngram 1 now --raw --after "$after" --exit-code "$exit_status" --cwd "$command_cwd" 2>/dev/null)
+        suggestion=$(command soon --shell zsh --ngram 1 now --raw --include-source --after "$after" --event-id "$event_id" --exit-code "$exit_status" --cwd "$command_cwd" 2>/dev/null)
         elapsed=$(( (EPOCHREALTIME - started) * 1000.0 ))
         printf '%.3f\t%s\n' $elapsed "$suggestion"
       )
@@ -162,7 +175,7 @@ if [[ -o interactive ]]; then
       _soon_prediction_event_id=''
       exec {_soon_fd}< <(
         local suggestion elapsed
-        suggestion=$(command soon --shell zsh now --raw 2>/dev/null)
+        suggestion=$(command soon --shell zsh now --raw --include-source 2>/dev/null)
         elapsed=$(( (EPOCHREALTIME - started) * 1000.0 ))
         printf '%.3f\t%s\n' $elapsed "$suggestion"
       )
@@ -187,19 +200,21 @@ if [[ -o interactive ]]; then
       _soon_record_suggestion dismissed
     fi
     if [[ -n $_soon_accepted_command && $1 == $_soon_accepted_command ]]; then
-      _soon_emit_suggestion executed "$_soon_accepted_id" "$_soon_accepted_trigger" "$_soon_accepted_event_id" "$_soon_accepted_latency" "$_soon_accepted_command"
+      _soon_emit_suggestion executed "$_soon_accepted_id" "$_soon_accepted_trigger" "$_soon_accepted_event_id" "$_soon_accepted_latency" "$_soon_accepted_source" "$_soon_accepted_command"
     fi
     _soon_accepted_command=''
     _soon_accepted_id=''
     _soon_accepted_trigger=''
     _soon_accepted_event_id=''
     _soon_accepted_latency=''
+    _soon_accepted_source=''
     _soon_cancel_prediction
     _soon_suggestion=''
     _soon_suggestion_id=''
     _soon_suggestion_trigger=''
     _soon_suggestion_event_id=''
     _soon_suggestion_latency=''
+    _soon_suggestion_source=''
     _soon_refresh_display
     local -a command_words=(${(z)1})
     if [[ ${command_words[1]:-} == soon ]] ||
@@ -245,9 +260,11 @@ if [[ -o interactive ]]; then
       _soon_accepted_trigger=$_soon_suggestion_trigger
       _soon_accepted_event_id=$_soon_suggestion_event_id
       _soon_accepted_latency=$_soon_suggestion_latency
+      _soon_accepted_source=$_soon_suggestion_source
       BUFFER=$_soon_suggestion
       CURSOR=${#BUFFER}
       _soon_suggestion=''
+      _soon_suggestion_source=''
       _soon_refresh_display
     else
       zle "$_soon_previous_ctrl_f"
@@ -264,6 +281,7 @@ if [[ -o interactive ]]; then
     zle -D _soon_accept 2>/dev/null || true
     zle -D _soon_apply_suggestion 2>/dev/null || true
     _soon_suggestion=''
+    _soon_suggestion_source=''
     _soon_highlight=''
   }
 

--- a/tests/events_cli.rs
+++ b/tests/events_cli.rs
@@ -35,6 +35,40 @@ fn record_command(
     exit_code: &str,
     previous_id: Option<&str>,
 ) {
+    record_command_in(
+        home,
+        id,
+        command,
+        exit_code,
+        previous_id,
+        "/tmp/soon-project",
+    );
+}
+
+fn record_command_in(
+    home: &PathBuf,
+    id: &str,
+    command: &str,
+    exit_code: &str,
+    previous_id: Option<&str>,
+    cwd: &str,
+) {
+    record_command_at(home, id, command, exit_code, previous_id, cwd, 1000, 25);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_command_at(
+    home: &PathBuf,
+    id: &str,
+    command: &str,
+    exit_code: &str,
+    previous_id: Option<&str>,
+    cwd: &str,
+    started_at_ms: i64,
+    duration_ms: u64,
+) {
+    let started_at_ms = started_at_ms.to_string();
+    let duration_ms = duration_ms.to_string();
     let mut args = vec![
         "events",
         "record-command",
@@ -43,11 +77,11 @@ fn record_command(
         "--command",
         command,
         "--cwd",
-        "/tmp/soon-project",
+        cwd,
         "--started-at-ms",
-        "1000",
+        &started_at_ms,
         "--duration-ms",
-        "25",
+        &duration_ms,
         "--exit-code",
         exit_code,
         "--shell",
@@ -64,6 +98,41 @@ fn record_command(
     assert!(
         output.status.success(),
         "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn record_suggestion_outcome(
+    home: &PathBuf,
+    id: &str,
+    command_event_id: &str,
+    command: &str,
+    outcome: &str,
+) {
+    let output = soon(home)
+        .args([
+            "events",
+            "record-suggestion",
+            "--id",
+            id,
+            "--command-event-id",
+            command_event_id,
+            "--trigger",
+            "next-step",
+            "--candidate-source",
+            "contextual-policy",
+            "--command",
+            command,
+            "--outcome",
+            outcome,
+            "--latency-ms",
+            "1.0",
+        ])
+        .output()
+        .expect("record suggestion outcome");
+    assert!(
+        output.status.success(),
+        "record suggestion outcome failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }
@@ -190,6 +259,922 @@ fn command_result_selects_repair_or_next_step_policy() {
     assert_eq!(
         String::from_utf8(next_step.stdout).expect("UTF-8 next step"),
         "git push --force-with-lease\n"
+    );
+}
+
+#[test]
+fn contextual_policy_can_be_enabled_to_rank_by_working_directory() {
+    let home = isolated_home();
+    record_command_in(&home, "a-previous", "cargo test", "0", None, "/work/a");
+    record_command_in(
+        &home,
+        "a-next",
+        "just deploy --env a",
+        "0",
+        Some("a-previous"),
+        "/work/a",
+    );
+    record_command_in(&home, "b1-previous", "cargo test", "0", None, "/work/b");
+    record_command_in(
+        &home,
+        "b1-next",
+        "just deploy --env b",
+        "0",
+        Some("b1-previous"),
+        "/work/b",
+    );
+    record_command_in(&home, "b2-previous", "cargo test", "0", None, "/work/b");
+    record_command_in(
+        &home,
+        "b2-next",
+        "just deploy --env b",
+        "0",
+        Some("b2-previous"),
+        "/work/b",
+    );
+
+    let configure_baseline = soon(&home)
+        .args(["config", "set", "prediction.policy", "v0.4-baseline"])
+        .output()
+        .expect("enable v0.4 baseline");
+    assert!(configure_baseline.status.success(), "configuration failed");
+
+    let baseline = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/a",
+        ])
+        .output()
+        .expect("predict with baseline");
+    assert!(baseline.status.success(), "baseline prediction failed");
+    assert_eq!(
+        String::from_utf8(baseline.stdout).expect("UTF-8 baseline"),
+        "just deploy --env b\n"
+    );
+
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(
+        configure.status.success(),
+        "configuration failed: {}",
+        String::from_utf8_lossy(&configure.stderr)
+    );
+    let contextual = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/a",
+        ])
+        .output()
+        .expect("predict with contextual policy");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(contextual.status.success(), "contextual prediction failed");
+    assert_eq!(
+        String::from_utf8(contextual.stdout).expect("UTF-8 contextual"),
+        "just deploy --env a\n"
+    );
+}
+
+#[test]
+fn contextual_policy_distinguishes_failure_repair_from_success_next_step() {
+    let home = isolated_home();
+    record_command(&home, "failed", "cargo build", "1", None);
+    record_command(
+        &home,
+        "repair",
+        "cargo build --verbose",
+        "0",
+        Some("failed"),
+    );
+    record_command(&home, "success", "cargo build", "0", Some("repair"));
+    record_command(&home, "next-step", "git diff --stat", "0", Some("success"));
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let repair = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo build",
+            "--exit-code",
+            "1",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict repair");
+    let next_step = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo build",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict next step");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(repair.status.success(), "repair prediction failed");
+    assert!(next_step.status.success(), "next-step prediction failed");
+    assert_eq!(
+        String::from_utf8(repair.stdout).expect("UTF-8 repair"),
+        "cargo build --verbose\n"
+    );
+    assert_eq!(
+        String::from_utf8(next_step.stdout).expect("UTF-8 next-step"),
+        "git diff --stat\n"
+    );
+}
+
+#[test]
+fn contextual_policy_uses_the_original_event_hour_bucket() {
+    let home = isolated_home();
+    record_command_at(
+        &home,
+        "day-previous",
+        "cargo test",
+        "0",
+        None,
+        "/work/project",
+        32_400_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "day-next",
+        "just deploy --window day",
+        "0",
+        Some("day-previous"),
+        "/work/project",
+        36_000_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "night-previous",
+        "cargo test",
+        "0",
+        Some("day-next"),
+        "/work/project",
+        75_600_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "night-next",
+        "just deploy --window night",
+        "0",
+        Some("night-previous"),
+        "/work/project",
+        79_200_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "current",
+        "cargo test",
+        "0",
+        Some("night-next"),
+        "/work/project",
+        640_800_000,
+        25,
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--event-id",
+            "current",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/project",
+        ])
+        .output()
+        .expect("predict by original time");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        prediction.status.success(),
+        "time-aware prediction failed: {}",
+        String::from_utf8_lossy(&prediction.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "just deploy --window day\n"
+    );
+}
+
+#[test]
+fn contextual_policy_uses_second_order_command_transitions() {
+    let home = isolated_home();
+    record_command(&home, "feature-before", "git add .", "0", None);
+    record_command(
+        &home,
+        "feature-commit",
+        "git commit",
+        "0",
+        Some("feature-before"),
+    );
+    record_command(
+        &home,
+        "feature-push",
+        "git push origin feature",
+        "0",
+        Some("feature-commit"),
+    );
+    record_command(&home, "main-before", "git pull", "0", None);
+    record_command(&home, "main-commit", "git commit", "0", Some("main-before"));
+    record_command(
+        &home,
+        "main-push",
+        "git push origin main",
+        "0",
+        Some("main-commit"),
+    );
+    record_command(&home, "current-before", "git add .", "0", None);
+    record_command(&home, "current", "git commit", "0", Some("current-before"));
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "git commit",
+            "--event-id",
+            "current",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict from second-order transition");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "git push origin feature\n"
+    );
+}
+
+#[test]
+fn contextual_policy_uses_accepted_and_executed_feedback() {
+    let home = isolated_home();
+    record_command(&home, "accepted-previous", "cargo test", "0", None);
+    record_command(
+        &home,
+        "accepted-next",
+        "just deploy --env stable",
+        "0",
+        Some("accepted-previous"),
+    );
+    record_command(&home, "recent-previous", "cargo test", "0", None);
+    record_command(
+        &home,
+        "recent-next",
+        "just deploy --env recent",
+        "0",
+        Some("recent-previous"),
+    );
+    record_suggestion_outcome(
+        &home,
+        "feedback-1",
+        "accepted-previous",
+        "just deploy --env stable",
+        "accepted",
+    );
+    record_suggestion_outcome(
+        &home,
+        "feedback-1",
+        "accepted-previous",
+        "just deploy --env stable",
+        "executed",
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict from feedback");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "just deploy --env stable\n"
+    );
+}
+
+#[test]
+fn contextual_debug_explains_signal_groups_without_claiming_confidence() {
+    let home = isolated_home();
+    let candidate = "cargo test --workspace";
+    record_command(&home, "previous", "git status", "0", None);
+    record_command(&home, "next", candidate, "0", Some("previous"));
+    record_suggestion_outcome(&home, "feedback", "previous", candidate, "accepted");
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--debug",
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "git status",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("debug contextual prediction");
+    let stdout = String::from_utf8(prediction.stdout).expect("UTF-8 stdout");
+    let stderr = String::from_utf8(prediction.stderr).expect("UTF-8 stderr");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed: {stderr}");
+    assert_eq!(stdout, format!("{candidate}\n"));
+    assert!(stderr.contains("Policy: contextual-policy"), "{stderr}");
+    assert!(
+        stderr.contains("Candidate source: event-history"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("Signal groups:"), "{stderr}");
+    assert!(stderr.contains("transition"), "{stderr}");
+    assert!(stderr.contains("feedback"), "{stderr}");
+    assert!(
+        !stderr.to_ascii_lowercase().contains("confidence"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains(candidate), "debug leaked candidate text");
+}
+
+#[test]
+fn contextual_policy_uses_the_previous_command_duration_bucket() {
+    let home = isolated_home();
+    record_command_at(
+        &home,
+        "short-previous",
+        "cargo test",
+        "0",
+        None,
+        "/work/project",
+        1_000,
+        200,
+    );
+    record_command_at(
+        &home,
+        "short-next",
+        "terminal-notifier -message short",
+        "0",
+        Some("short-previous"),
+        "/work/project",
+        2_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "long-previous",
+        "cargo test",
+        "0",
+        None,
+        "/work/project",
+        3_000,
+        90_000,
+    );
+    record_command_at(
+        &home,
+        "long-next",
+        "terminal-notifier -message long",
+        "0",
+        Some("long-previous"),
+        "/work/project",
+        4_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "current",
+        "cargo test",
+        "0",
+        None,
+        "/work/project",
+        5_000,
+        300,
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--event-id",
+            "current",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/project",
+        ])
+        .output()
+        .expect("predict by duration");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "terminal-notifier -message short\n"
+    );
+}
+
+#[test]
+fn contextual_policy_uses_the_original_event_weekday() {
+    let home = isolated_home();
+    record_command_at(
+        &home,
+        "thursday-previous",
+        "git fetch",
+        "0",
+        None,
+        "/work/project",
+        32_400_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "thursday-next",
+        "just report --day thursday",
+        "0",
+        Some("thursday-previous"),
+        "/work/project",
+        36_000_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "friday-previous",
+        "git fetch",
+        "0",
+        None,
+        "/work/project",
+        118_800_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "friday-next",
+        "just report --day friday",
+        "0",
+        Some("friday-previous"),
+        "/work/project",
+        122_400_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "current",
+        "git fetch",
+        "0",
+        None,
+        "/work/project",
+        640_800_000,
+        25,
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "git fetch",
+            "--event-id",
+            "current",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/project",
+        ])
+        .output()
+        .expect("predict by weekday");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "just report --day thursday\n"
+    );
+}
+
+#[test]
+fn contextual_policy_uses_repository_and_branch_when_known() {
+    let home = isolated_home();
+    let project_a = home.join("work/project-a");
+    let project_b = home.join("work/project-b");
+    std::fs::create_dir_all(project_a.join(".git")).expect("create project A git dir");
+    std::fs::create_dir_all(project_b.join(".git")).expect("create project B git dir");
+    std::fs::write(project_a.join(".git/HEAD"), "ref: refs/heads/feature\n")
+        .expect("write project A feature branch");
+    std::fs::write(project_b.join(".git/HEAD"), "ref: refs/heads/feature\n")
+        .expect("write project B feature branch");
+    let project_a = project_a.to_str().expect("UTF-8 project A");
+    let project_b = project_b.to_str().expect("UTF-8 project B");
+
+    record_command_in(&home, "a-previous", "cargo test", "0", None, project_a);
+    record_command_in(
+        &home,
+        "a-next",
+        "just deploy project-a-feature",
+        "0",
+        Some("a-previous"),
+        project_a,
+    );
+    record_command_in(&home, "b-previous", "cargo test", "0", None, project_b);
+    record_command_in(
+        &home,
+        "b-next",
+        "just deploy project-b-feature",
+        "0",
+        Some("b-previous"),
+        project_b,
+    );
+    std::fs::write(
+        std::path::Path::new(project_a).join(".git/HEAD"),
+        "ref: refs/heads/main\n",
+    )
+    .expect("switch project A to main");
+    record_command_in(&home, "main-previous", "cargo test", "0", None, project_a);
+    record_command_in(
+        &home,
+        "main-next",
+        "just deploy project-a-main",
+        "0",
+        Some("main-previous"),
+        project_a,
+    );
+    std::fs::write(
+        std::path::Path::new(project_a).join(".git/HEAD"),
+        "ref: refs/heads/feature\n",
+    )
+    .expect("switch project A back to feature");
+    record_command_in(&home, "current", "cargo test", "0", None, project_a);
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--event-id",
+            "current",
+            "--exit-code",
+            "0",
+            "--cwd",
+            project_a,
+        ])
+        .output()
+        .expect("predict by repository and branch");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "just deploy project-a-feature\n"
+    );
+}
+
+#[test]
+fn contextual_policy_combines_smoothed_evidence_instead_of_one_lexicographic_signal() {
+    let home = isolated_home();
+    record_command_at(
+        &home,
+        "consistent-previous",
+        "cargo test",
+        "0",
+        None,
+        "/work/other",
+        32_400_000,
+        200,
+    );
+    record_command_at(
+        &home,
+        "consistent-next",
+        "just deploy --evidence consistent",
+        "0",
+        Some("consistent-previous"),
+        "/work/other",
+        36_000_000,
+        25,
+    );
+    record_suggestion_outcome(
+        &home,
+        "accepted-consistent",
+        "consistent-previous",
+        "just deploy --evidence consistent",
+        "accepted",
+    );
+    record_command_at(
+        &home,
+        "directory-previous",
+        "cargo test",
+        "1",
+        None,
+        "/work/current",
+        118_800_000,
+        90_000,
+    );
+    record_command_at(
+        &home,
+        "directory-next",
+        "just deploy --evidence directory-only",
+        "0",
+        Some("directory-previous"),
+        "/work/current",
+        165_600_000,
+        25,
+    );
+    record_command_at(
+        &home,
+        "current",
+        "cargo test",
+        "0",
+        None,
+        "/work/current",
+        640_800_000,
+        200,
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "cargo test",
+            "--event-id",
+            "current",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/current",
+        ])
+        .output()
+        .expect("predict from combined evidence");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "just deploy --evidence consistent\n"
+    );
+}
+
+#[test]
+fn contextual_policy_treats_missing_historical_metadata_as_no_evidence() {
+    let home = isolated_home();
+    let history = home.join("plain-history");
+    std::fs::write(&history, "git status\ncargo test --workspace\n").expect("write plain history");
+    let import = soon(&home)
+        .args([
+            "events",
+            "import-zsh",
+            "--path",
+            history.to_str().expect("UTF-8 history path"),
+        ])
+        .output()
+        .expect("import history without metadata");
+    assert!(import.status.success(), "history import failed");
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--debug",
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--after",
+            "git status",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/work/unknown",
+        ])
+        .output()
+        .expect("predict with missing metadata");
+    let stdout = String::from_utf8(prediction.stdout).expect("UTF-8 stdout");
+    let stderr = String::from_utf8(prediction.stderr).expect("UTF-8 stderr");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed: {stderr}");
+    assert_eq!(stdout, "cargo test --workspace\n");
+    assert!(
+        stderr.contains("Signal groups: transition, frequency, recency"),
+        "{stderr}"
+    );
+    for absent in ["directory", "time", "result", "duration"] {
+        assert!(
+            !stderr.contains(absent),
+            "invented {absent} evidence: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn contextual_policy_ordering_is_deterministic_across_processes() {
+    let home = isolated_home();
+    record_command(&home, "first-previous", "git status", "0", None);
+    record_command(
+        &home,
+        "first-next",
+        "cargo test --package first",
+        "0",
+        Some("first-previous"),
+    );
+    record_command(&home, "second-previous", "git status", "0", None);
+    record_command(
+        &home,
+        "second-next",
+        "cargo test --package second",
+        "0",
+        Some("second-previous"),
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let mut predictions = Vec::new();
+    for _ in 0..8 {
+        let prediction = soon(&home)
+            .args([
+                "--shell",
+                "zsh",
+                "now",
+                "--raw",
+                "--after",
+                "git status",
+                "--exit-code",
+                "0",
+                "--cwd",
+                "/tmp/soon-project",
+            ])
+            .output()
+            .expect("repeat contextual prediction");
+        assert!(prediction.status.success(), "prediction failed");
+        predictions.push(String::from_utf8(prediction.stdout).expect("UTF-8 prediction"));
+    }
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(
+        predictions
+            .iter()
+            .all(|prediction| prediction == &predictions[0]),
+        "predictions changed across processes: {predictions:?}"
+    );
+    assert_eq!(predictions[0], "cargo test --package second\n");
+}
+
+#[test]
+fn raw_prediction_can_report_the_selected_policy_source() {
+    let home = isolated_home();
+    record_command(&home, "previous", "git status", "0", None);
+    record_command(
+        &home,
+        "next",
+        "cargo test --workspace",
+        "0",
+        Some("previous"),
+    );
+    let configure = soon(&home)
+        .args(["config", "set", "prediction.policy", "contextual"])
+        .output()
+        .expect("enable contextual policy");
+    assert!(configure.status.success(), "configuration failed");
+
+    let prediction = soon(&home)
+        .args([
+            "--shell",
+            "zsh",
+            "now",
+            "--raw",
+            "--include-source",
+            "--after",
+            "git status",
+            "--exit-code",
+            "0",
+            "--cwd",
+            "/tmp/soon-project",
+        ])
+        .output()
+        .expect("predict with source metadata");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(prediction.status.success(), "prediction failed");
+    assert_eq!(
+        String::from_utf8(prediction.stdout).expect("UTF-8 prediction"),
+        "contextual-policy\tcargo test --workspace\n"
     );
 }
 

--- a/tests/replay_cli.rs
+++ b/tests/replay_cli.rs
@@ -109,6 +109,41 @@ fn record_suggestion(
     );
 }
 
+fn record_suggestion_outcome(
+    home: &PathBuf,
+    id: &str,
+    command_event_id: &str,
+    text: &str,
+    outcome: &str,
+) {
+    let output = soon(home)
+        .args([
+            "events",
+            "record-suggestion",
+            "--id",
+            id,
+            "--command-event-id",
+            command_event_id,
+            "--trigger",
+            "next-step",
+            "--candidate-source",
+            "contextual-policy",
+            "--command",
+            text,
+            "--outcome",
+            outcome,
+            "--latency-ms",
+            "1.0",
+        ])
+        .output()
+        .expect("record suggestion outcome");
+    assert!(
+        output.status.success(),
+        "record suggestion outcome failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn chronological_replay_never_learns_from_the_sample_being_scored() {
     let home = isolated_home();
@@ -140,6 +175,59 @@ fn chronological_replay_never_learns_from_the_sample_being_scored() {
     assert!(stdout.contains("Zsh p95 budget: PASS"), "{stdout}");
     assert!(stdout.contains("next-step"), "{stdout}");
     assert!(stdout.contains("history"), "{stdout}");
+    for (_, text, _) in commands {
+        assert!(
+            !stdout.contains(text),
+            "replay leaked command text: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn replay_compares_the_contextual_policy_with_the_v04_baseline() {
+    let home = isolated_home();
+    let commands = [
+        ("command-1", "git status", None),
+        ("command-2", "cargo test --workspace", Some("command-1")),
+        ("command-3", "git status", Some("command-2")),
+        ("command-4", "cargo test --workspace", Some("command-3")),
+    ];
+    for (id, text, previous_id) in commands {
+        record_command(&home, id, text, "0", previous_id);
+    }
+
+    let replay = soon(&home).arg("replay").output().expect("replay events");
+    let stdout = String::from_utf8(replay.stdout).expect("UTF-8 replay output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(replay.status.success(), "replay failed");
+    let baseline = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("v0.4-baseline"))
+        .expect("v0.4 baseline row");
+    let contextual = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("contextual-policy"))
+        .expect("contextual policy row");
+    assert!(baseline.contains("samples=3"), "{stdout}");
+    assert!(baseline.contains("coverage="), "{stdout}");
+    assert!(baseline.contains("top-1="), "{stdout}");
+    assert!(baseline.contains("p50="), "{stdout}");
+    assert!(baseline.contains("p95="), "{stdout}");
+    assert!(contextual.contains("samples=3"), "{stdout}");
+    assert!(contextual.contains("coverage="), "{stdout}");
+    assert!(contextual.contains("top-1="), "{stdout}");
+    assert!(contextual.contains("p50="), "{stdout}");
+    assert!(contextual.contains("p95="), "{stdout}");
+    assert!(
+        stdout.contains("Configured policy: contextual-policy"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Contextual promotion gate:"), "{stdout}");
+    assert!(
+        stdout.contains("requires top-1 > baseline and p95 <= 20 ms"),
+        "{stdout}"
+    );
     for (_, text, _) in commands {
         assert!(
             !stdout.contains(text),
@@ -283,4 +371,44 @@ fn recorded_sources_and_model_failures_are_scored_only_after_they_occur() {
         !stdout.contains(actual),
         "replay leaked command text: {stdout}"
     );
+}
+
+#[test]
+fn contextual_replay_uses_feedback_available_before_the_actual_command() {
+    let home = isolated_home();
+    let stable = "just deploy --env stable";
+    record_command(&home, "stable-previous", "cargo test", "0", None);
+    record_command(&home, "stable-next", stable, "0", Some("stable-previous"));
+    record_command(&home, "recent-previous", "cargo test", "0", None);
+    record_command(
+        &home,
+        "recent-next",
+        "just deploy --env recent",
+        "0",
+        Some("recent-previous"),
+    );
+    record_suggestion_outcome(
+        &home,
+        "accepted-stable",
+        "recent-previous",
+        stable,
+        "accepted",
+    );
+    record_command(&home, "current", "cargo test", "0", None);
+    record_command(&home, "actual", stable, "0", Some("current"));
+
+    let replay = soon(&home).arg("replay").output().expect("replay events");
+    let stdout = String::from_utf8(replay.stdout).expect("UTF-8 replay output");
+
+    let _ = std::fs::remove_dir_all(&home);
+    assert!(replay.status.success(), "replay failed");
+    let contextual = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("contextual-policy"))
+        .expect("contextual policy row");
+    assert!(
+        contextual.contains("samples=3 coverage=66.7% top-1=33.3%"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains(stable), "replay leaked command text");
 }

--- a/tests/zsh_integration.zsh
+++ b/tests/zsh_integration.zsh
@@ -35,10 +35,14 @@ case " \$* " in
   *' events record-command '*|*' events record-suggestion '*) exit 0 ;;
 esac
 sleep 0.05
+prefix=''
 case " \$* " in
-  *' --exit-code 0 '*) printf '%s\n' 'touch $accepted_file' ;;
-  *' --exit-code '*) printf '%s\n' 'touch $repair_file' ;;
-  *) printf '%s\n' 'touch $accepted_file' ;;
+  *' --include-source '*) prefix="deterministic-history	" ;;
+esac
+case " \$* " in
+  *' --exit-code 0 '*) printf '%b%s\n' "\$prefix" 'touch $accepted_file' ;;
+  *' --exit-code '*) printf '%b%s\n' "\$prefix" 'touch $repair_file' ;;
+  *) printf '%b%s\n' "\$prefix" 'touch $accepted_file' ;;
 esac
 FAKE_SOON
 chmod +x $fake_bin/soon
@@ -128,6 +132,7 @@ function wait_for_log() {
 wait_for_output 'SOON_PROMPT> '
 wait_for_output "touch $accepted_file"
 wait_for_log '--outcome shown'
+wait_for_log '--candidate-source deterministic-history'
 zpty -w -n soon_shell $'\x06'
 wait_for_log '--outcome accepted'
 sleep 0.05

--- a/tests/zsh_integration.zsh
+++ b/tests/zsh_integration.zsh
@@ -135,10 +135,12 @@ wait_for_log '--outcome shown'
 wait_for_log '--candidate-source deterministic-history'
 zpty -w -n soon_shell $'\x06'
 wait_for_log '--outcome accepted'
+wait_for_log "--candidate-source deterministic-history --command touch $accepted_file --outcome accepted"
 sleep 0.05
 zpty -w -n soon_shell $'\n'
 wait_for_file $accepted_file
 wait_for_log '--outcome executed'
+wait_for_log "--candidate-source deterministic-history --command touch $accepted_file --outcome executed"
 wait_for_output 'SOON_PROMPT> '
 
 # Normal typing ignores the ghost suggestion instead of modifying the buffer.


### PR DESCRIPTION
## Summary

- route online prediction and chronological replay through one candidate-source/ranker module
- add a smoothed contextual policy over full commands, including transitions, directory, Git context, time, result, duration, recency, and feedback
- preserve missing metadata as unknown and expose signal-group debug output without confidence claims or command leakage
- compare contextual and v0.4 policies by coverage, exact top-1, p50, and p95, with a 20 ms promotion gate
- carry the selected policy source through Zsh shown/accepted/executed events and document the policy contract

## Impact

The v0.5 source defaults to the local contextual policy after it passed the promotion gate. `prediction.policy = "v0.4-baseline"` remains an explicit offline fallback. No prediction path requires a model or network service, and suggestions are never executed automatically.

An aggregate-only local replay over 31 transitions measured:

- v0.4 baseline: 48.4% coverage, 32.3% top-1, 0.092 ms p95
- contextual policy: 96.8% coverage, 35.5% top-1, 0.366 ms p95

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (66 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `zsh tests/zsh_integration.zsh target/debug/soon`
- `uvx pre-commit run --all-files`
- `cargo package --locked --allow-dirty`
- `zsh tests/release_smoke.zsh target/debug/soon`
- `python3 tests/site_smoke.py`
- `git diff --check`

Closes #16
Refs #4

## Summary by Sourcery

引入一种具备历史与上下文感知能力的预测策略，与现有的 v0.4 基线策略并行存在，并将其贯通至 CLI、replay 和 Zsh 集成；同时将该上下文策略作为可配置的默认策略，并保留显式的 v0.4 回退选项。

New Features:
- 添加一种基于上下文的整条命令预测策略，综合考虑状态转移、目录、Git 仓库/分支、时间点、持续时长、结果、最近度以及反馈信号，并采用确定性的排序方式。
- 暴露可配置的 `prediction.policy` 设置，将 `contextual` 作为 v0.5 的默认策略，将 `v0.4-baseline` 作为显式回退；同时支持原始输出（raw-output），用于返回所选策略来源。
- 扩展命令事件，以捕获从 `.git` 中发现的可选 Git 仓库和分支上下文（无需调用 `git`），并在 Zsh 集成生命周期中暴露策略/来源的元数据。

Enhancements:
- 将预测重构为共享的 prediction 模块，拆分为候选检索与排序两个接口，由旧的基线策略和新的上下文策略共同复用。
- 更新 replay，使其能够并行评估基线和上下文策略，报告每种策略的覆盖率/top-1/延迟，并基于准确率和 20 ms 的 p95 延迟预算强制执行“晋升门槛”（promotion gate）。
- 增强预测的调试输出，以描述当前生效的策略、候选来源以及所贡献的信号分组，同时避免泄露命令文本或隐含置信度。
- 改进原始预测输出和 shell 接线逻辑，以在展示/接受/执行建议事件中传递并记录所选策略来源。

Documentation:
- 文档化上下文预测策略，其使用的信号、平滑（smoothing）机制和晋升门槛（promotion gate），并更新 README 中关于预测器、replay、配置和路线图的说明，以体现新的默认上下文策略。

Tests:
- 添加覆盖面广泛的 CLI、replay 和 Zsh 集成测试，覆盖目录、Git 上下文、时间、持续时长、状态转移、反馈、确定性、缺失元数据、策略对比以及来源传播等情形下的上下文策略行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a contextual, history- and context-aware prediction policy alongside the existing v0.4 baseline and wire it through CLI, replay, and Zsh integration, making contextual the default configurable policy while preserving an explicit v0.4 fallback.

New Features:
- Add a contextual full-command prediction policy that incorporates transitions, directory, Git repository/branch, timing, duration, result, recency, and feedback signals with deterministic ranking.
- Expose a configurable prediction.policy setting with contextual as the v0.5 default and v0.4-baseline as an explicit fallback, including raw-output support for returning the selected policy source.
- Extend command events to capture optional Git repository and branch context discovered from .git without invoking git, and surface policy/source metadata through the Zsh integration lifecycle.

Enhancements:
- Refactor prediction into a shared prediction module with separate candidate-retrieval and ranking interfaces used by both the legacy baseline and the new contextual policy.
- Update replay to evaluate baseline and contextual policies side by side, report per-policy coverage/top-1/latency, and enforce a promotion gate based on accuracy and a 20 ms p95 latency budget.
- Enhance debug output for predictions to describe the active policy, candidate source, and contributing signal groups without leaking command text or implied confidence.
- Improve raw prediction output and shell wiring to carry and record the selected policy source through shown/accepted/executed suggestion events.

Documentation:
- Document the contextual prediction policy, its signals, smoothing, and promotion gate, and update README guidance around predictors, replay, configuration, and roadmap to reflect the new default contextual policy.

Tests:
- Add extensive CLI, replay, and Zsh integration tests covering contextual policy behavior across directory, Git context, time, duration, transitions, feedback, determinism, missing metadata, policy comparison, and source propagation.

</details>