### PR TITLE
feat: add opt-in model candidate sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to soon are documented here.
   chronological promotion comparison against the v0.4 baseline. It is the v0.5
   source default after passing the quality and latency gate; `v0.4-baseline`
   remains an explicit fallback ([#16](https://github.com/HsiangNianian/soon/issues/16)).
+- Added opt-in local and OpenAI-compatible candidate sources for bounded
+  rerank, Repair, and explicit Generate modes. Provider context is minimal and
+  filtered, model output is treated as untrusted, deadlines fall back to the
+  deterministic policy, and Zsh/replay retain source and outcome attribution
+  ([#17](https://github.com/HsiangNianian/soon/issues/17)).
 
 ## 0.4.2 - 2026-07-29
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ soon config set prediction.policy v0.4-baseline
 # Export aggregate adoption metrics that are safe to share
 soon report
 soon report --json
+
+# Explicitly ask a configured OpenAI-compatible provider; never auto-executes
+soon generate
 ```
 
 Override shell detection when needed:
@@ -138,6 +141,10 @@ The v0.4 baseline matches recurring transitions, preserves complete historical c
 
 The contextual policy separates candidate retrieval from ranking, then combines first- and second-order transitions, cwd, optional repository and branch, original time, result, duration, frequency, recency, and accepted/executed feedback. Missing metadata contributes no evidence. Its additive smoothing, weights, debug contract, and deterministic tie-breaking are documented in [Contextual prediction policy](docs/contextual-policy.md).
 
+Optional local and OpenAI-compatible sources can rerank safe history candidates, suggest a Repair after failure, or Generate only on explicit request. They have a hard deadline and silently retain the deterministic result on timeout, unavailability, or invalid output. The default is `prediction.model_mode = "off"`. The exact provider payload, output filters, ranking feature, and fallback protocol are documented in [Optional model candidate sources](docs/model-sources.md).
+
+The [small local model gate](docs/model-evaluation.md) tested Qwen2.5-Coder 0.5B Q4_K_M on an Intel Mac. It added one exact cold-start Repair across eight public fixtures at 676.2 ms p95, which was enough to validate the optional path but not enough quality evidence to enable it by default.
+
 The v0.5 source promotes contextual after it improved exact top-1 without reducing coverage or exceeding the 20 ms p95 budget in both the deterministic fixture and a local aggregate replay. `v0.4-baseline` remains an explicit offline fallback.
 
 ## Agent roadmap
@@ -146,11 +153,11 @@ The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) co
 
 The closed [v0.4.1 Adoption Sprint](https://github.com/HsiangNianian/soon/milestone/3) added the public demo, launch assets, and privacy-safe report. The planned ten-user pilot and final timed launch measurements were explicitly closed as not planned rather than reported as completed.
 
-The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) then measures a contextual probabilistic ranker in [#16](https://github.com/HsiangNianian/soon/issues/16) before adding opt-in local-model and OpenAI-compatible candidate sources in [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
+The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) promotes the contextual probabilistic ranker from [#16](https://github.com/HsiangNianian/soon/issues/16) and adds the opt-in local-model/OpenAI-compatible layer from [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
 
 ## Privacy
 
-`soon`, `soon now`, `soon replay`, `soon report`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the local predictor in a background process; it does not upload history or block the prompt while waiting for a result.
+With the default `prediction.model_mode = "off"`, `soon`, `soon now`, `soon replay`, `soon report`, `soon init zsh`, and the local learning commands read files on your machine and do not require a network service. The Zsh integration invokes the predictor in a background process and does not block the prompt while waiting for a result. An opt-in model mode or explicit `soon generate` may contact only the configured provider.
 
 The current source rejects likely inline API keys, tokens, authorization headers, password flags, private-key material, and known credential prefixes before storing a command or suggestion. It applies the same filter again before ranking or rendering shell history, old event data, legacy learn data, provider context, and model output. Rejections report a category, not the command text.
 
@@ -163,19 +170,19 @@ soon config set privacy.excluded_patterns '(?i)^kubectl .*--context production'
 
 Comma-separated values configure more than one exclusion. Literal values are redacted from `soon config`, `config get`, and successful `config set` output. Invalid regular expressions are rejected before the configuration is saved.
 
-`soon learn ask` is different: it is an optional experimental path that sends only filtered recent commands and the current directory to the OpenAI-compatible or Ollama endpoint you configure. It does not send event IDs, exit codes, feedback, stdout, or stderr. Model candidates pass through the same local filter before display.
+The v0.5 model candidate path sends at most six filtered commands, the current command and result class, and at most five local candidates to an OpenAI-compatible endpoint. It omits paths, repository metadata, event IDs, timestamps, duration, feedback, stdout, and stderr. Model output is filtered again for control characters, credentials, configured exclusions, and dangerous commands before entering the contextual ranker. The older `soon learn ask` experiment remains separate and includes the filtered current directory.
 
 Provider credentials are read at request time from an environment variable and are never stored or printed by soon. The default variable is `SOON_LLM_API_KEY`; configure a different variable name with `llm.api_key_env`. For example, this Zsh flow keeps the value out of shell history:
 
 ```zsh
-soon config set llm.provider openai
-soon config set llm.api_url https://api.openai.com
+soon config set llm.provider openai-compatible
+soon config set llm.api_url https://provider.example/v1
 read -rs 'SOON_LLM_API_KEY?API key: '
 print
 export SOON_LLM_API_KEY
 ```
 
-Ollama can run without a credential. The legacy `llm.api_key` setting is rejected.
+A local OpenAI-compatible endpoint can run without a credential. The legacy `llm.api_key` setting is rejected.
 
 The Zsh lifecycle integration stores local command and suggestion events in a retained JSONL log under the operating system's application-data directory. When cwd is inside a Git worktree, the background recorder also reads the repository root and symbolic branch directly from `.git/HEAD`; it does not spawn `git`. Inspect the store's exact path, schema version, retention, and aggregate counts without printing command text:
 
@@ -258,6 +265,9 @@ soon config get general.ngram
 soon config set general.ngram 5
 soon config get prediction.policy
 soon config set prediction.policy v0.4-baseline  # explicit fallback
+soon config get prediction.model_mode            # off by default
+soon config set prediction.model_mode repair      # opt-in model path
+soon config set prediction.model_timeout_ms 1500
 soon config set update.channel cargo  # or pip
 ```
 
@@ -266,6 +276,7 @@ soon config set update.channel cargo  # or pip
 ```text
 soon                    Predict the next full command
 soon now                Run the same prediction explicitly
+soon generate           Explicitly request a model candidate
 soon init zsh           Print the opt-in Zsh integration
 soon stats              Show the most-used executables
 soon which              Show shell and history diagnostics
@@ -279,7 +290,7 @@ soon update             Check the configured release channel
 
 ## Contributing
 
-Start with [RFC #4](https://github.com/HsiangNianian/soon/issues/4), then choose an open issue from the [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2). The contextual ranker is tracked in [#16](https://github.com/HsiangNianian/soon/issues/16); optional model-backed sources remain sequenced in [#17](https://github.com/HsiangNianian/soon/issues/17).
+Start with [RFC #4](https://github.com/HsiangNianian/soon/issues/4), then choose an open issue from the [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2). The contextual ranker is tracked in [#16](https://github.com/HsiangNianian/soon/issues/16), and the opt-in model candidate layer is tracked in [#17](https://github.com/HsiangNianian/soon/issues/17).
 
 For local verification:
 

--- a/docs/contextual-policy.md
+++ b/docs/contextual-policy.md
@@ -18,6 +18,8 @@ Candidate retrieval and ranking are separate interfaces in `src/prediction.rs`:
 
 The v0.4 baseline retrieves matching first-order transitions and applies its deterministic frequency, result, directory, and recency ordering. The contextual policy retrieves complete commands from event history. When any first-order transition is available, unrelated candidates are removed before ranking; otherwise the full safe history provides a cold-start fallback.
 
+Opt-in model candidates enter this same contextual ranker through the external candidate-source boundary. Their provider contract, model-order feature, deadline, filtering, and deterministic fallback are documented in [Optional model candidate sources](model-sources.md).
+
 ## Evidence
 
 The contextual ranker combines these local signals:

--- a/docs/model-evaluation.md
+++ b/docs/model-evaluation.md
@@ -1,0 +1,45 @@
+# Small local model evaluation
+
+This is the release gate for the optional model candidate source in #17. The fixture and output are aggregate-only and reproducible; it does not read the maintainer's shell history.
+
+## Environment
+
+- Date: 2026-07-30
+- Machine: macOS x86_64, Intel Core i9-9980HK, 32 GiB RAM
+- Runner: [llama.cpp b10195](https://github.com/ggml-org/llama.cpp/releases/tag/b10195), official macOS x64 binary, version `10195 (47f686f53)`
+- Model: [Qwen2.5-Coder-0.5B-Instruct-GGUF](https://huggingface.co/Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF), `Q4_K_M`, model revision `ebb2015119c907b064c512bf053e945850b5875f`
+- Model SHA-256: `1d9614638d18024d0fbb36575a15f1302a3adf044df10345688ec4f6e1c4ff32`
+- Model file: 469 MiB; observed server RSS after evaluation: approximately 662 MiB
+- Model deadline for the run: 10,000 ms. The release default remains 1,500 ms.
+
+## Fixture
+
+[`scripts/evaluate_model.py`](../scripts/evaluate_model.py) contains eight public failed-command typo fixtures. Each sample gets an isolated temporary HOME and event store. The contextual baseline and the local-model Repair path see the same failed command; no personal history, credentials, paths, stdout, or stderr enter the run.
+
+Run against an already-started OpenAI-compatible local server:
+
+```bash
+cargo build --locked
+python3 scripts/evaluate_model.py \
+  --soon target/debug/soon \
+  --api-url http://127.0.0.1:18089/v1 \
+  --model qwen2.5-coder-0.5b-instruct-q4_k_m.gguf \
+  --timeout-ms 10000
+```
+
+## Result
+
+```text
+Samples: 8
+contextual-policy: coverage=0.0% top1=0.0% p50=16.7ms p95=24.7ms
+local-model: coverage=12.5% top1=12.5% p50=408.2ms p95=676.2ms
+outcomes: no-safe-candidate=7, success=1
+```
+
+An immediate warm repeat kept the same 1/8 quality result and measured contextual p50/p95 at 16.3/17.6 ms and local-model p50/p95 at 401.8/428.8 ms. The decision below uses the more conservative first-run model p95 rather than selecting the warmer number.
+
+The fixture is intentionally cold-start Repair: it contains the failed command but no prior correction, so the history-only policy has no candidate. The 0.5B model produced one exact correction. Seven responses repeated the failed command; the contextual ranker rejected that self-candidate and rendered nothing.
+
+## Decision
+
+The model path stays optional. It demonstrated measurable cold-start coverage and stayed within the default 1,500 ms model deadline on this machine, but one exact match out of eight is not enough quality evidence to put inference on the default hot path. The deterministic contextual policy remains the default, and provider failures or unsafe/invalid responses continue to fall back locally when a deterministic candidate exists.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -1,0 +1,72 @@
+# Optional model candidate sources
+
+Model-backed candidates are opt-in. `prediction.model_mode` defaults to `off`, so `soon`, `soon now`, and the Zsh hooks do not contact a provider unless the user changes that setting. `soon generate` is the separate explicit generation path.
+
+All new model paths use an OpenAI-compatible Chat Completions endpoint. The policy layer does not branch on a model vendor. `llm.provider` only controls source attribution: `local` and the legacy `ollama` name record `local-model`; other values record `remote-provider`.
+
+## Configuration
+
+Run a small model through a local OpenAI-compatible endpoint:
+
+```bash
+soon config set llm.provider local
+soon config set llm.api_url http://127.0.0.1:11434/v1
+soon config set llm.model qwen2.5-coder:1.5b
+soon config set prediction.model_timeout_ms 1500
+soon config set prediction.model_mode repair
+```
+
+Use any remote OpenAI-compatible service for explicit generation:
+
+```bash
+soon config set llm.provider openai-compatible
+soon config set llm.api_url https://provider.example/v1
+soon config set llm.model provider-model-name
+soon config set llm.api_key_env SOON_LLM_API_KEY
+soon generate
+```
+
+The credential value is read from the named environment variable at request time. It is not saved in `config.toml` or printed by soon.
+
+Automatic modes are:
+
+| `prediction.model_mode` | Behavior |
+|---|---|
+| `off` | Default. No model request on the ordinary prediction path. |
+| `rerank` | Ask the model to order up to five safe local candidates after any completed command. |
+| `repair` | Ask for a minimal correction only after a non-zero exit status. |
+| `rerank-repair` | Rerank after success and request a Repair candidate after failure. |
+
+`soon generate` always means an explicit Generate attempt; it does not enable an automatic mode. Every output is only printed or placed in the editable Zsh buffer. No model path executes a candidate or presses Enter.
+
+## Provider contract
+
+The provider receives one system message and one user message. Depending on the mode, the user message contains only:
+
+- mode: `rerank`, `repair`, or `generate`;
+- the current command when it passes the privacy filter;
+- the previous result class: `success`, `failure`, or unknown;
+- at most six recent safe commands for Rerank or Generate;
+- at most five safe local candidates. Repair intentionally omits recent history and sends only the filtered failed command plus this shortlist.
+
+It does not include cwd, repository paths, branch names, event IDs, timestamps, duration, feedback, stdout, or stderr. Events rejected by built-in or configured privacy rules are removed before the payload is built.
+
+The response message content must be strict JSON:
+
+```json
+{"commands":["cargo test --workspace","cargo clippy --all-targets"]}
+```
+
+Rerank output may only contain commands from the supplied local shortlist. Repair and Generate may propose a command absent from history. In every mode, output is treated as untrusted: empty strings, control characters, credentials, configured exclusions, ignored executables, forced recursive deletion, device writes, destructive Git reset/clean/push, remote-script pipes, and system shutdown commands are rejected before ranking or rendering. Responses are capped at 64 KiB.
+
+## Deadline, ranking, and fallback
+
+`prediction.model_timeout_ms` is a hard whole-request deadline from 10 to 30,000 ms; the default is 1,500 ms. Timeout, unavailable provider, malformed JSON, and a response with no safe candidate silently retain the deterministic result.
+
+Safe model candidates enter the same contextual ranker as historical candidates. Model order contributes `8 * ln(1 + remaining_rank)` as an uncalibrated ranking feature; transition, context, feedback, frequency, recency, and deterministic tie-breaking still apply. A selected model candidate is attributed to `local-model` or `remote-provider`. A failed attempt that returns the local result is attributed to `deterministic-fallback` and records `timeout`, `invalid-output`, or `deterministic-fallback` as its model outcome.
+
+The Zsh integration records that source and outcome on shown, accepted, executed, and dismissed events. `soon replay` reports source-specific coverage, top-1, p50, and p95, plus aggregate model timeout, invalid-output, and unavailable-provider fallback rates. It never prints command text.
+
+## Evaluation gate
+
+The deterministic contextual policy stays the default. A small local model remains optional unless chronological Repair or cold-start top-1 improves and its observed latency stays within the configured model deadline. Mock-provider tests cover the protocol without credentials. The reproducible [0.5B local-model evaluation](model-evaluation.md) records the real model, quantization, machine, fixture, quality, latency, resource use, and the decision to keep it opt-in.

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Run an aggregate-only local-model Repair evaluation against soon."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+
+
+CASES = (
+    ("git statsu", "git status"),
+    ("cargo tset", "cargo test"),
+    ("npm tset", "npm test"),
+    ("pyest tests/test_api.py", "pytest tests/test_api.py"),
+    ("docker ps --al", "docker ps --all"),
+    ("kubectl get pdoes", "kubectl get pods"),
+    ("rg --fiels", "rg --files"),
+    ("git chekcout main", "git checkout main"),
+)
+
+
+def run(soon: Path, home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("SOON_LLM_API_KEY", None)
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "XDG_DATA_HOME": str(home / ".local/share"),
+        }
+    )
+    return subprocess.run(
+        [str(soon), *args],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def checked(soon: Path, home: Path, *args: str) -> None:
+    result = run(soon, home, *args)
+    if result.returncode != 0:
+        raise RuntimeError(f"soon command failed while preparing evaluation: {args[0]}")
+
+
+def predict(soon: Path, home: Path, failed: str) -> tuple[str, str, str, float]:
+    started = time.perf_counter()
+    result = run(
+        soon,
+        home,
+        "now",
+        "--raw",
+        "--include-source",
+        "--after",
+        failed,
+        "--exit-code",
+        "1",
+        "--event-id",
+        "failed-current",
+        "--cwd",
+        "/tmp/soon-public-model-fixture",
+    )
+    latency_ms = (time.perf_counter() - started) * 1000
+    if result.returncode != 0 and not result.stdout.strip():
+        return "", "", "", latency_ms
+    if result.returncode != 0:
+        raise RuntimeError("soon prediction failed during evaluation")
+    fields = result.stdout.rstrip("\n").split("\t", 2)
+    if fields == [""]:
+        return "", "", "", latency_ms
+    if len(fields) == 2:
+        return fields[0], "", fields[1], latency_ms
+    if len(fields) == 3:
+        return fields[0], fields[1], fields[2], latency_ms
+    return "", "invalid-output", "", latency_ms
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(1, math.ceil(quantile * len(ordered)))
+    return ordered[min(rank - 1, len(ordered) - 1)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--soon", type=Path, default=Path("target/debug/soon"))
+    parser.add_argument("--api-url", default="http://127.0.0.1:18089/v1")
+    parser.add_argument(
+        "--model", default="qwen2.5-coder-0.5b-instruct-q4_k_m.gguf"
+    )
+    parser.add_argument("--timeout-ms", type=int, default=10_000)
+    args = parser.parse_args()
+
+    soon = args.soon.resolve()
+    if not soon.is_file():
+        raise SystemExit("soon binary not found; run cargo build --locked first")
+
+    baseline_predictions = 0
+    baseline_matches = 0
+    baseline_latencies: list[float] = []
+    model_predictions = 0
+    model_matches = 0
+    model_latencies: list[float] = []
+    outcomes: dict[str, int] = {}
+
+    root = Path(tempfile.mkdtemp(prefix="soon-public-model-eval-"))
+    try:
+        for index, (failed, expected) in enumerate(CASES):
+            home = root / str(index)
+            home.mkdir(parents=True)
+            checked(
+                soon,
+                home,
+                "events",
+                "record-command",
+                "--id",
+                "failed-current",
+                "--command",
+                failed,
+                "--cwd",
+                "/tmp/soon-public-model-fixture",
+                "--started-at-ms",
+                "1000",
+                "--duration-ms",
+                "25",
+                "--exit-code",
+                "1",
+                "--shell",
+                "zsh",
+            )
+
+            _, _, baseline, latency = predict(soon, home, failed)
+            baseline_latencies.append(latency)
+            baseline_predictions += int(bool(baseline))
+            baseline_matches += int(baseline == expected)
+
+            checked(soon, home, "config", "set", "llm.provider", "local")
+            checked(soon, home, "config", "set", "llm.api_url", args.api_url)
+            checked(soon, home, "config", "set", "llm.model", args.model)
+            checked(
+                soon,
+                home,
+                "config",
+                "set",
+                "prediction.model_timeout_ms",
+                str(args.timeout_ms),
+            )
+            checked(soon, home, "config", "set", "prediction.model_mode", "repair")
+
+            _, outcome, model, latency = predict(soon, home, failed)
+            model_latencies.append(latency)
+            model_predictions += int(bool(model))
+            model_matches += int(model == expected)
+            aggregate_outcome = outcome or "no-safe-candidate"
+            outcomes[aggregate_outcome] = outcomes.get(aggregate_outcome, 0) + 1
+    finally:
+        shutil.rmtree(root)
+
+    samples = len(CASES)
+    print("Aggregate local-model Repair evaluation")
+    print(f"Samples: {samples}")
+    print(
+        "contextual-policy: "
+        f"coverage={baseline_predictions / samples * 100:.1f}% "
+        f"top1={baseline_matches / samples * 100:.1f}% "
+        f"p50={percentile(baseline_latencies, 0.50):.1f}ms "
+        f"p95={percentile(baseline_latencies, 0.95):.1f}ms"
+    )
+    print(
+        "local-model: "
+        f"coverage={model_predictions / samples * 100:.1f}% "
+        f"top1={model_matches / samples * 100:.1f}% "
+        f"p50={percentile(model_latencies, 0.50):.1f}ms "
+        f"p95={percentile(model_latencies, 0.95):.1f}ms"
+    )
+    print(
+        "outcomes: "
+        + ", ".join(f"{name}={count}" for name, count in sorted(outcomes.items()))
+    )
+    print("Privacy: public fixtures only; no user history or command text printed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,15 @@ pub enum Commands {
         #[arg(long, hide = true, requires = "after")]
         cwd: Option<String>,
     },
+    /// Explicitly ask an opt-in model provider for a command candidate
+    Generate {
+        /// Print only the generated command
+        #[arg(long)]
+        raw: bool,
+        /// Prefix raw output with source and model outcome
+        #[arg(long, hide = true, requires = "raw")]
+        include_source: bool,
+    },
     /// Show most used commands
     Stats,
     /// Learn from command history and predict intelligently

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -75,7 +75,7 @@ fn get_value(key: &str) {
             eprintln!("  general.shell, general.ngram, general.ignored_commands");
             eprintln!("  update.channel");
             eprintln!("  events.retention");
-            eprintln!("  prediction.policy");
+            eprintln!("  prediction.policy, prediction.model_mode, prediction.model_timeout_ms");
             eprintln!("  privacy.excluded_literals, privacy.excluded_patterns");
             eprintln!("  llm.provider, llm.api_url, llm.api_key_env, llm.model, llm.prompt");
             std::process::exit(1);

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,0 +1,35 @@
+use colored::Colorize;
+
+use crate::config::AppConfig;
+use crate::events;
+
+pub fn run(config: &AppConfig, raw: bool, include_source: bool) {
+    let prediction = events::predict_explicit_model(config);
+    if raw {
+        if let Some(prediction) = prediction {
+            if include_source {
+                println!(
+                    "{}\t{}\t{}",
+                    prediction.candidate_source,
+                    prediction
+                        .model_outcome
+                        .map(|outcome| outcome.label())
+                        .unwrap_or(""),
+                    prediction.command
+                );
+            } else {
+                println!("{}", prediction.command);
+            }
+        }
+        return;
+    }
+
+    println!(
+        "\n{}",
+        "Suggested candidate (never executed):".magenta().bold()
+    );
+    match prediction {
+        Some(prediction) => println!("  {} {}", ">".green().bold(), prediction.command.green()),
+        None => println!("{}", "  No safe candidate".dimmed()),
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod events;
+pub mod generate;
 pub mod init;
 pub mod learn;
 pub mod now;

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -36,9 +36,15 @@ pub fn run(
                     eprintln!("  Candidate source: {}", suggestion.candidate_source);
                     eprintln!("  Signal groups: {}", suggestion.signal_groups.join(", "));
                 }
+                let source = if suggestion.model_outcome.is_some() {
+                    suggestion.candidate_source
+                } else {
+                    suggestion.policy.event_source()
+                };
                 print_raw_suggestion(
                     Some(suggestion.command),
-                    suggestion.policy.event_source(),
+                    source,
+                    suggestion.model_outcome,
                     context.include_source,
                 );
                 return;
@@ -65,7 +71,12 @@ pub fn run(
         predict::predict_next_command(&history, ngram, &cache_cmds, config, debug && !raw);
 
     if raw {
-        print_raw_suggestion(suggestion, "deterministic-history", context.include_source);
+        print_raw_suggestion(
+            suggestion,
+            "deterministic-history",
+            None,
+            context.include_source,
+        );
         return;
     }
 
@@ -126,10 +137,19 @@ pub fn run(
     }
 }
 
-fn print_raw_suggestion(suggestion: Option<String>, source: &str, include_source: bool) {
+fn print_raw_suggestion(
+    suggestion: Option<String>,
+    source: &str,
+    model_outcome: Option<crate::events::ModelOutcome>,
+    include_source: bool,
+) {
     if let Some(cmd) = suggestion.filter(|cmd| !cmd.chars().any(char::is_control)) {
         if include_source {
-            println!("{source}\t{cmd}");
+            if let Some(outcome) = model_outcome {
+                println!("{source}\t{}\t{cmd}", outcome.label());
+            } else {
+                println!("{source}\t{cmd}");
+            }
         } else {
             println!("{cmd}");
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,10 @@ pub struct EventsConfig {
 pub struct PredictionConfig {
     #[serde(default = "default_prediction_policy")]
     pub policy: String,
+    #[serde(default = "default_model_mode")]
+    pub model_mode: String,
+    #[serde(default = "default_model_timeout_ms")]
+    pub model_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -86,6 +90,14 @@ fn default_event_retention() -> usize {
 
 fn default_prediction_policy() -> String {
     "contextual".to_string()
+}
+
+fn default_model_mode() -> String {
+    "off".to_string()
+}
+
+fn default_model_timeout_ms() -> u64 {
+    1_500
 }
 
 fn default_api_key_env() -> String {
@@ -133,6 +145,8 @@ impl Default for PredictionConfig {
     fn default() -> Self {
         Self {
             policy: default_prediction_policy(),
+            model_mode: default_model_mode(),
+            model_timeout_ms: default_model_timeout_ms(),
         }
     }
 }
@@ -195,6 +209,8 @@ impl AppConfig {
             "llm.prompt" => Some(self.llm.prompt.clone()),
             "events.retention" => Some(self.events.retention.to_string()),
             "prediction.policy" => Some(self.prediction.policy.clone()),
+            "prediction.model_mode" => Some(self.prediction.model_mode.clone()),
+            "prediction.model_timeout_ms" => Some(self.prediction.model_timeout_ms.to_string()),
             "privacy.excluded_literals" => Some(format!(
                 "[{}]",
                 vec!["<redacted>"; self.privacy.excluded_literals.len()].join(", ")
@@ -265,6 +281,23 @@ impl AppConfig {
                 }
                 self.prediction.policy = value.to_string();
             }
+            "prediction.model_mode" => {
+                if !matches!(value, "off" | "rerank" | "repair" | "rerank-repair") {
+                    return Err(
+                        "Invalid model mode. Valid: off, rerank, repair, rerank-repair".to_string(),
+                    );
+                }
+                self.prediction.model_mode = value.to_string();
+            }
+            "prediction.model_timeout_ms" => {
+                let timeout = value
+                    .parse::<u64>()
+                    .map_err(|_| format!("Invalid model timeout: {value}"))?;
+                if !(10..=30_000).contains(&timeout) {
+                    return Err("Model timeout must be between 10 and 30000 ms".to_string());
+                }
+                self.prediction.model_timeout_ms = timeout;
+            }
             "privacy.excluded_literals" => {
                 self.privacy.excluded_literals = parse_list(value);
             }
@@ -323,5 +356,21 @@ mod tests {
     #[test]
     fn contextual_policy_is_the_default_after_passing_the_promotion_gate() {
         assert_eq!(AppConfig::default().prediction.policy, "contextual");
+        assert_eq!(AppConfig::default().prediction.model_mode, "off");
+    }
+
+    #[test]
+    fn model_prediction_config_validates_mode_and_deadline() {
+        let mut config = AppConfig::default();
+        assert!(config.set_value("prediction.model_mode", "repair").is_ok());
+        assert!(config
+            .set_value("prediction.model_mode", "always-online")
+            .is_err());
+        assert!(config
+            .set_value("prediction.model_timeout_ms", "40")
+            .is_ok());
+        assert!(config
+            .set_value("prediction.model_timeout_ms", "0")
+            .is_err());
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -5,6 +5,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 use crate::config::AppConfig;
+use crate::model_prediction;
 use crate::prediction::{self, Memory};
 use crate::privacy;
 
@@ -65,6 +66,15 @@ impl ModelOutcome {
             "invalid-output" => Ok(Self::InvalidOutput),
             "deterministic-fallback" => Ok(Self::DeterministicFallback),
             _ => Err(format!("Unknown model outcome: {value}")),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Timeout => "timeout",
+            Self::InvalidOutput => "invalid-output",
+            Self::DeterministicFallback => "deterministic-fallback",
         }
     }
 }
@@ -327,10 +337,54 @@ pub fn predict_after(
         previous_event_id: None,
     };
     let current = stored_current.unwrap_or(&synthetic_current);
-    prediction::predict(
+    let deterministic = prediction::predict(
         prediction::configured_policy(config),
         current,
         &memory,
+        config,
+    );
+    model_prediction::augment_if_configured(current, &memory, deterministic, config)
+}
+
+pub fn predict_explicit_model(config: &AppConfig) -> Option<prediction::Prediction> {
+    let events = load_stored_events(&event_store_path());
+    let memory = Memory::from_stored(&events);
+    let synthetic = CommandEvent {
+        schema_version: SCHEMA_VERSION,
+        id: String::new(),
+        command: String::new(),
+        cwd: std::env::current_dir()
+            .ok()
+            .map(|path| path.to_string_lossy().into_owned()),
+        repository: None,
+        branch: None,
+        started_at_ms: None,
+        duration_ms: None,
+        exit_code: None,
+        shell: String::new(),
+        previous_event_id: None,
+    };
+    let current = memory
+        .commands
+        .iter()
+        .rev()
+        .copied()
+        .find(|event| {
+            !event.command.chars().any(char::is_control)
+                && privacy::rejection_reason(&event.command, config).is_none()
+        })
+        .unwrap_or(&synthetic);
+    let deterministic = prediction::predict(
+        prediction::configured_policy(config),
+        current,
+        &memory,
+        config,
+    );
+    model_prediction::augment(
+        current,
+        &memory,
+        deterministic,
+        model_prediction::Mode::Generate,
         config,
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod events;
 mod history_import;
 mod learn;
+mod model_prediction;
 mod predict;
 mod prediction;
 mod privacy;
@@ -76,6 +77,10 @@ fn main() {
                 },
             );
         }
+        Some(Commands::Generate {
+            raw,
+            include_source,
+        }) => commands::generate::run(&config, raw, include_source),
         None => {
             require_known_shell(&shell);
             commands::now::run(

--- a/src/model_prediction.rs
+++ b/src/model_prediction.rs
@@ -1,0 +1,364 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
+use crate::config::AppConfig;
+use crate::events::{CommandEvent, ModelOutcome};
+use crate::predict::{is_ignored_command, main_cmd};
+use crate::prediction::{self, ExternalCandidate, Memory, Prediction};
+use crate::privacy;
+
+const MAX_CONTEXT_COMMANDS: usize = 6;
+const MAX_CANDIDATES: usize = 5;
+const MAX_RESPONSE_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Rerank,
+    Repair,
+    Generate,
+}
+
+impl Mode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Rerank => "rerank",
+            Self::Repair => "repair",
+            Self::Generate => "generate",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AttemptError {
+    Timeout,
+    InvalidOutput,
+    Unavailable,
+}
+
+pub fn configured_mode(config: &AppConfig, exit_code: Option<i32>) -> Option<Mode> {
+    match config.prediction.model_mode.as_str() {
+        "rerank" => Some(Mode::Rerank),
+        "repair" if exit_code.is_some_and(|code| code != 0) => Some(Mode::Repair),
+        "rerank-repair" if exit_code.is_some_and(|code| code != 0) => Some(Mode::Repair),
+        "rerank-repair" => Some(Mode::Rerank),
+        _ => None,
+    }
+}
+
+pub fn augment_if_configured(
+    current: &CommandEvent,
+    memory: &Memory<'_>,
+    deterministic: Option<Prediction>,
+    config: &AppConfig,
+) -> Option<Prediction> {
+    let Some(mode) = configured_mode(config, current.exit_code) else {
+        return deterministic;
+    };
+    augment(current, memory, deterministic, mode, config)
+}
+
+pub fn augment(
+    current: &CommandEvent,
+    memory: &Memory<'_>,
+    deterministic: Option<Prediction>,
+    mode: Mode,
+    config: &AppConfig,
+) -> Option<Prediction> {
+    let local_candidates =
+        prediction::local_candidate_shortlist(current, memory, config, MAX_CANDIDATES);
+    match request_candidates(mode, current, memory, &local_candidates, config) {
+        Ok(external) => {
+            if let Some(mut selected) =
+                prediction::predict_with_external(current, memory, &external, config)
+            {
+                selected.model_outcome = Some(ModelOutcome::Success);
+                Some(selected)
+            } else {
+                fallback(deterministic, ModelOutcome::InvalidOutput)
+            }
+        }
+        Err(AttemptError::Timeout) => fallback(deterministic, ModelOutcome::Timeout),
+        Err(AttemptError::InvalidOutput) => fallback(deterministic, ModelOutcome::InvalidOutput),
+        Err(AttemptError::Unavailable) => {
+            fallback(deterministic, ModelOutcome::DeterministicFallback)
+        }
+    }
+}
+
+fn fallback(deterministic: Option<Prediction>, model_outcome: ModelOutcome) -> Option<Prediction> {
+    deterministic.map(|mut prediction| {
+        prediction.candidate_source = "deterministic-fallback";
+        prediction.model_outcome = Some(model_outcome);
+        prediction
+    })
+}
+
+fn request_candidates(
+    mode: Mode,
+    current: &CommandEvent,
+    memory: &Memory<'_>,
+    local_candidates: &[String],
+    config: &AppConfig,
+) -> Result<Vec<ExternalCandidate>, AttemptError> {
+    if config.llm.api_url.trim().is_empty() || config.llm.model.trim().is_empty() {
+        return Err(AttemptError::Unavailable);
+    }
+    if mode == Mode::Rerank && local_candidates.is_empty() {
+        return Err(AttemptError::Unavailable);
+    }
+
+    let recent_commands = filtered_recent_commands(memory, config);
+    let current_command = (privacy::rejection_reason(&current.command, config).is_none()
+        && !current.command.chars().any(char::is_control)
+        && !current.command.trim().is_empty())
+    .then(|| current.command.trim().to_string());
+    let result = current
+        .exit_code
+        .map(|code| if code == 0 { "success" } else { "failure" });
+    let context = serde_json::json!({
+        "mode": mode.label(),
+        "current_command": current_command,
+        "previous_result": result,
+        "recent_commands": recent_commands,
+        "local_candidates": local_candidates,
+    });
+    let (system_prompt, user_prompt) = match mode {
+        Mode::Rerank => (
+            "You rerank shell command text but never execute commands. Return strict JSON only."
+                .to_string(),
+            format!(
+                "Return only a JSON object with a commands array. Reorder only commands from local_candidates.\nContext:\n{context}"
+            ),
+        ),
+        Mode::Repair => (
+            "You repair failed shell commands. Never repeat the failed command. Correct obvious misspellings or flag errors. Return strict JSON only."
+                .to_string(),
+            format!(
+                "The command failed. Return only {{\"commands\":[\"corrected command\"]}}. Failed command: {}\nFiltered local candidates: {}",
+                current_command.as_deref().unwrap_or("unknown"),
+                serde_json::to_string(local_candidates)
+                    .map_err(|_| AttemptError::InvalidOutput)?
+            ),
+        ),
+        Mode::Generate => (
+            "You suggest shell command text but never execute commands. Return strict JSON only."
+                .to_string(),
+            format!(
+                "Return only a JSON object with a commands array containing likely next shell commands.\nContext:\n{context}"
+            ),
+        ),
+    };
+    let request_body = serde_json::json!({
+        "model": config.llm.model,
+        "messages": [
+            {
+                "role": "system",
+                "content": system_prompt
+            },
+            {
+                "role": "user",
+                "content": user_prompt
+            }
+        ],
+        "temperature": 0.0,
+        "max_tokens": 256
+    });
+
+    let agent_config = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_millis(
+            config.prediction.model_timeout_ms,
+        )))
+        .build();
+    let agent: ureq::Agent = agent_config.into();
+    let mut request = agent
+        .post(&provider_url(&config.llm.api_url))
+        .header("Content-Type", "application/json");
+    if let Ok(api_key) = std::env::var(&config.llm.api_key_env) {
+        if !api_key.is_empty() {
+            request = request.header("Authorization", &format!("Bearer {api_key}"));
+        }
+    }
+    let encoded = serde_json::to_vec(&request_body).map_err(|_| AttemptError::InvalidOutput)?;
+    let mut response = request
+        .send(encoded.as_slice())
+        .map_err(|error| match error {
+            ureq::Error::Timeout(_) => AttemptError::Timeout,
+            _ => AttemptError::Unavailable,
+        })?;
+    let response_text = response
+        .body_mut()
+        .with_config()
+        .limit(MAX_RESPONSE_BYTES)
+        .read_to_string()
+        .map_err(|_| AttemptError::InvalidOutput)?;
+    let response_json: serde_json::Value =
+        serde_json::from_str(&response_text).map_err(|_| AttemptError::InvalidOutput)?;
+    let content = response_json
+        .get("choices")
+        .and_then(|choices| choices.get(0))
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("content"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or(AttemptError::InvalidOutput)?;
+    parse_candidates(
+        mode,
+        content,
+        local_candidates,
+        provider_source(config),
+        config,
+    )
+}
+
+fn provider_url(configured: &str) -> String {
+    let base = configured.trim_end_matches('/');
+    if base.ends_with("/chat/completions") {
+        base.to_string()
+    } else if base.ends_with("/v1") {
+        format!("{base}/chat/completions")
+    } else {
+        format!("{base}/v1/chat/completions")
+    }
+}
+
+fn provider_source(config: &AppConfig) -> &'static str {
+    match config.llm.provider.trim().to_ascii_lowercase().as_str() {
+        "local" | "ollama" => "local-model",
+        _ => "remote-provider",
+    }
+}
+
+fn filtered_recent_commands(memory: &Memory<'_>, config: &AppConfig) -> Vec<String> {
+    let mut commands = memory
+        .commands
+        .iter()
+        .rev()
+        .filter(|event| {
+            !event.command.chars().any(char::is_control)
+                && privacy::rejection_reason(&event.command, config).is_none()
+        })
+        .map(|event| event.command.trim().to_string())
+        .filter(|command| !command.is_empty())
+        .take(MAX_CONTEXT_COMMANDS)
+        .collect::<Vec<_>>();
+    commands.reverse();
+    commands
+}
+
+fn parse_candidates(
+    mode: Mode,
+    content: &str,
+    local_candidates: &[String],
+    source: &'static str,
+    config: &AppConfig,
+) -> Result<Vec<ExternalCandidate>, AttemptError> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(json_object(content)).map_err(|_| AttemptError::InvalidOutput)?;
+    let commands = parsed
+        .get("commands")
+        .and_then(serde_json::Value::as_array)
+        .ok_or(AttemptError::InvalidOutput)?;
+    let allowed: HashSet<&str> = local_candidates.iter().map(String::as_str).collect();
+    let mut seen = HashSet::new();
+    let mut safe = Vec::new();
+    for value in commands {
+        let Some(command) = value.as_str().map(str::trim) else {
+            continue;
+        };
+        if (mode == Mode::Rerank && !allowed.contains(command))
+            || privacy::model_candidate_rejection_reason(command, config).is_some()
+            || is_ignored_command(main_cmd(command), config)
+            || !seen.insert(command.to_string())
+        {
+            continue;
+        }
+        safe.push(command.to_string());
+        if safe.len() == MAX_CANDIDATES {
+            break;
+        }
+    }
+    if safe.is_empty() {
+        return Err(AttemptError::InvalidOutput);
+    }
+    let candidate_count = safe.len();
+    Ok(safe
+        .into_iter()
+        .enumerate()
+        .map(|(rank, command)| ExternalCandidate {
+            command,
+            source,
+            rank,
+            candidate_count,
+        })
+        .collect())
+}
+
+fn json_object(content: &str) -> &str {
+    let trimmed = content.trim();
+    let unfenced = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .and_then(|value| value.strip_suffix("```"))
+        .map(str::trim)
+        .unwrap_or(trimmed);
+    unfenced
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_urls_are_normalized_without_a_vendor_branch() {
+        assert_eq!(
+            provider_url("http://127.0.0.1:11434"),
+            "http://127.0.0.1:11434/v1/chat/completions"
+        );
+        assert_eq!(
+            provider_url("https://provider.example/v1"),
+            "https://provider.example/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn rerank_accepts_only_safe_local_candidates() {
+        let local = vec!["cargo test".to_string(), "cargo clippy".to_string()];
+        let parsed = parse_candidates(
+            Mode::Rerank,
+            r#"{"commands":["cargo clippy","cargo publish"]}"#,
+            &local,
+            "local-model",
+            &AppConfig::default(),
+        )
+        .expect("parse rerank");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].command, "cargo clippy");
+    }
+
+    #[test]
+    fn generated_secrets_and_control_characters_are_untrusted() {
+        let parsed = parse_candidates(
+            Mode::Generate,
+            r#"{"commands":["deploy --token model-secret-value","cargo test\nrm -rf target","cargo check"]}"#,
+            &[],
+            "remote-provider",
+            &AppConfig::default(),
+        )
+        .expect("parse generated candidates");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].command, "cargo check");
+    }
+
+    #[test]
+    fn fenced_json_is_still_parsed_as_untrusted_candidate_data() {
+        let parsed = parse_candidates(
+            Mode::Repair,
+            "```json\n{\"commands\":[\"git status\"]}\n```",
+            &[],
+            "local-model",
+            &AppConfig::default(),
+        )
+        .expect("parse fenced model response");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].command, "git status");
+    }
+}

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::{Datelike, TimeZone, Timelike, Utc};
 
 use crate::config::AppConfig;
-use crate::events::{CommandEvent, StoredEvent, SuggestionEvent, SuggestionOutcome};
+use crate::events::{CommandEvent, ModelOutcome, StoredEvent, SuggestionEvent, SuggestionOutcome};
 use crate::predict::{is_ignored_command, main_cmd};
 use crate::privacy;
 
@@ -35,6 +35,15 @@ pub struct Prediction {
     pub policy: PolicyKind,
     pub candidate_source: &'static str,
     pub signal_groups: Vec<&'static str>,
+    pub model_outcome: Option<ModelOutcome>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExternalCandidate {
+    pub command: String,
+    pub source: &'static str,
+    pub rank: usize,
+    pub candidate_count: usize,
 }
 
 #[derive(Default)]
@@ -61,9 +70,10 @@ impl<'a> Memory<'a> {
 }
 
 struct Candidate<'a> {
-    command: &'a str,
+    command: String,
     source: &'static str,
     observations: Vec<Observation<'a>>,
+    model_rank: Option<(usize, usize)>,
 }
 
 struct Observation<'a> {
@@ -136,9 +146,10 @@ impl CandidateSource for TransitionHistorySource {
             candidates
                 .entry(next.command.trim())
                 .or_insert_with(|| Candidate {
-                    command: next.command.trim(),
+                    command: next.command.trim().to_string(),
                     source: self.label(),
                     observations: Vec::new(),
+                    model_rank: None,
                 })
                 .observations
                 .push(Observation {
@@ -201,13 +212,14 @@ impl Ranker for V04Ranker {
                 .then_with(|| score_b.directory_matches.cmp(&score_a.directory_matches))
                 .then_with(|| score_b.evidence.cmp(&score_a.evidence))
                 .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
-                .then_with(|| candidate_a.command.cmp(candidate_b.command))
+                .then_with(|| candidate_a.command.cmp(&candidate_b.command))
         });
         ranked.into_iter().next().map(|(candidate, _)| Prediction {
             command: candidate.command.to_string(),
             policy: PolicyKind::V04Baseline,
             candidate_source: candidate.source,
             signal_groups: v04_signal_groups(current, &candidate),
+            model_outcome: None,
         })
     }
 }
@@ -269,9 +281,10 @@ impl CandidateSource for FullHistorySource {
             candidates
                 .entry(event.command.trim())
                 .or_insert_with(|| Candidate {
-                    command: event.command.trim(),
+                    command: event.command.trim().to_string(),
                     source: self.label(),
                     observations: Vec::new(),
+                    model_rank: None,
                 })
                 .observations
                 .push(Observation {
@@ -307,6 +320,7 @@ struct ContextualScore {
     first_order_matches: usize,
     first_order_known: usize,
     feedback: usize,
+    model_support: bool,
     evidence: usize,
     latest_index: usize,
 }
@@ -339,11 +353,12 @@ impl Ranker for ContextualRanker {
         });
         if has_first_order_evidence {
             candidates.retain(|candidate| {
-                candidate.observations.iter().any(|observation| {
-                    observation
-                        .previous
-                        .is_some_and(|event| event.command.trim() == current.command.trim())
-                })
+                candidate.model_rank.is_some()
+                    || candidate.observations.iter().any(|observation| {
+                        observation
+                            .previous
+                            .is_some_and(|event| event.command.trim() == current.command.trim())
+                    })
             });
         } else {
             candidates.retain(|candidate| candidate.command != current.command.trim());
@@ -467,14 +482,19 @@ impl Ranker for ContextualRanker {
                 let feedback = memory
                     .suggestions
                     .iter()
-                    .filter(|event| event.command.trim() == candidate.command)
+                    .filter(|event| event.command.trim() == candidate.command.as_str())
                     .map(|event| match event.outcome {
                         SuggestionOutcome::Accepted => 2,
                         SuggestionOutcome::Executed => 4,
                         SuggestionOutcome::Shown | SuggestionOutcome::Dismissed => 0,
                     })
                     .sum();
-                let mut score = ContextualScore { feedback, ..score };
+                let model_support = candidate.model_rank.is_some();
+                let mut score = ContextualScore {
+                    feedback,
+                    model_support,
+                    ..score
+                };
                 score.total = smoothed_prior(score.evidence, total_evidence, candidate_count)
                     + 2.0 * smoothed_match(score.first_order_matches, score.first_order_known, 2)
                     + 2.5 * smoothed_match(score.second_order_matches, score.second_order_known, 2)
@@ -486,6 +506,13 @@ impl Ranker for ContextualRanker {
                     + 1.5 * smoothed_match(score.result_matches, score.result_known, 2)
                     + 0.75 * smoothed_match(score.duration_matches, score.duration_known, 4)
                     + 1.5 * (score.feedback as f64).ln_1p()
+                    + candidate
+                        .model_rank
+                        .map(|(rank, total)| {
+                            let preference = total.saturating_sub(rank).max(1) as f64;
+                            8.0 * preference.ln_1p()
+                        })
+                        .unwrap_or(0.0)
                     + 0.25 * score.latest_index as f64 / max_index as f64;
                 (candidate, score)
             })
@@ -496,7 +523,7 @@ impl Ranker for ContextualRanker {
                 .total_cmp(&score_a.total)
                 .then_with(|| score_b.evidence.cmp(&score_a.evidence))
                 .then_with(|| score_b.latest_index.cmp(&score_a.latest_index))
-                .then_with(|| candidate_a.command.cmp(candidate_b.command))
+                .then_with(|| candidate_a.command.cmp(&candidate_b.command))
         });
         ranked
             .into_iter()
@@ -506,6 +533,7 @@ impl Ranker for ContextualRanker {
                 policy: PolicyKind::Contextual,
                 candidate_source: candidate.source,
                 signal_groups: contextual_signal_groups(current, &candidate, &score),
+                model_outcome: None,
             })
     }
 }
@@ -572,6 +600,9 @@ fn contextual_signal_groups(
     if score.feedback > 0 {
         groups.push("feedback");
     }
+    if score.model_support {
+        groups.push("model");
+    }
     groups.extend(["frequency", "recency"]);
     groups
 }
@@ -627,6 +658,85 @@ pub fn predict(
             ContextualRanker.rank(current, candidates, memory)
         }
     }
+}
+
+pub fn predict_with_external(
+    current: &CommandEvent,
+    memory: &Memory<'_>,
+    external: &[ExternalCandidate],
+    config: &AppConfig,
+) -> Option<Prediction> {
+    let mut candidates = FullHistorySource.retrieve(current, memory, config);
+    for model_candidate in external {
+        if privacy::model_candidate_rejection_reason(&model_candidate.command, config).is_some()
+            || is_ignored_command(main_cmd(&model_candidate.command), config)
+        {
+            continue;
+        }
+        if let Some(candidate) = candidates
+            .iter_mut()
+            .find(|candidate| candidate.command == model_candidate.command.trim())
+        {
+            candidate.source = model_candidate.source;
+            candidate.model_rank = Some((model_candidate.rank, model_candidate.candidate_count));
+        } else {
+            candidates.push(Candidate {
+                command: model_candidate.command.trim().to_string(),
+                source: model_candidate.source,
+                observations: Vec::new(),
+                model_rank: Some((model_candidate.rank, model_candidate.candidate_count)),
+            });
+        }
+    }
+    ContextualRanker.rank(current, candidates, memory)
+}
+
+pub fn local_candidate_shortlist(
+    current: &CommandEvent,
+    memory: &Memory<'_>,
+    config: &AppConfig,
+    limit: usize,
+) -> Vec<String> {
+    let mut candidates = FullHistorySource.retrieve(current, memory, config);
+    let has_transition = candidates.iter().any(|candidate| {
+        candidate.observations.iter().any(|observation| {
+            observation
+                .previous
+                .is_some_and(|event| event.command.trim() == current.command.trim())
+        })
+    });
+    if has_transition {
+        candidates.retain(|candidate| {
+            candidate.observations.iter().any(|observation| {
+                observation
+                    .previous
+                    .is_some_and(|event| event.command.trim() == current.command.trim())
+            })
+        });
+    }
+    candidates.sort_by(|a, b| {
+        b.observations
+            .len()
+            .cmp(&a.observations.len())
+            .then_with(|| {
+                b.observations
+                    .iter()
+                    .map(|observation| observation.index)
+                    .max()
+                    .cmp(
+                        &a.observations
+                            .iter()
+                            .map(|observation| observation.index)
+                            .max(),
+                    )
+            })
+            .then_with(|| a.command.cmp(&b.command))
+    });
+    candidates
+        .into_iter()
+        .map(|candidate| candidate.command)
+        .take(limit)
+        .collect()
 }
 
 pub fn configured_policy(config: &AppConfig) -> PolicyKind {

--- a/src/privacy.rs
+++ b/src/privacy.rs
@@ -26,6 +26,59 @@ pub fn rejection_reason(command: &str, config: &AppConfig) -> Option<&'static st
     built_in_rejection_reason(command)
 }
 
+pub fn model_candidate_rejection_reason(command: &str, config: &AppConfig) -> Option<&'static str> {
+    if command.trim().is_empty() || command.chars().any(char::is_control) {
+        return Some("invalid command text");
+    }
+    rejection_reason(command, config).or_else(|| dangerous_model_command(command))
+}
+
+fn dangerous_model_command(command: &str) -> Option<&'static str> {
+    let normalized = command
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    let effective = normalized.strip_prefix("sudo ").unwrap_or(&normalized);
+    let words: Vec<_> = effective.split_whitespace().collect();
+    let destructive_recursive_delete = words.first() == Some(&"rm")
+        && words
+            .iter()
+            .filter(|word| word.starts_with('-'))
+            .flat_map(|word| word.trim_start_matches('-').chars())
+            .any(|flag| flag == 'r')
+        && words
+            .iter()
+            .filter(|word| word.starts_with('-'))
+            .flat_map(|word| word.trim_start_matches('-').chars())
+            .any(|flag| flag == 'f');
+    let destructive_device_write = words.first().is_some_and(|word| word.starts_with("mkfs"))
+        || (words.first() == Some(&"dd") && effective.contains(" of=/dev/"));
+    let remote_shell = matches!(words.first(), Some(&"curl" | &"wget"))
+        && (effective.contains(" | sh") || effective.contains(" | bash"));
+    let system_control = matches!(
+        words.first(),
+        Some(&"shutdown" | &"reboot" | &"halt" | &"poweroff")
+    );
+    let destructive_git = words.first() == Some(&"git")
+        && ((words.get(1) == Some(&"reset") && words.contains(&"--hard"))
+            || (words.get(1) == Some(&"clean")
+                && words.iter().skip(2).any(|word| {
+                    word.starts_with('-') && word.trim_start_matches('-').contains('f')
+                }))
+            || (words.get(1) == Some(&"push")
+                && words
+                    .iter()
+                    .any(|word| matches!(*word, "--force" | "--force-with-lease"))));
+
+    (destructive_recursive_delete
+        || destructive_device_write
+        || remote_shell
+        || system_control
+        || destructive_git)
+        .then_some("dangerous model command")
+}
+
 fn built_in_rejection_reason(command: &str) -> Option<&'static str> {
     let normalized = command.to_ascii_lowercase();
 
@@ -87,6 +140,38 @@ mod tests {
                 rejection_reason(command, &AppConfig::default()),
                 None,
                 "unexpected rejection: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_dangerous_model_commands_without_rejecting_normal_repairs() {
+        let config = AppConfig::default();
+        for command in [
+            "rm -rf /",
+            "rm -fr $HOME",
+            "sudo rm -rf / --no-preserve-root",
+            "rm -r -f target",
+            "dd if=image.iso of=/dev/disk2",
+            "curl https://example.test/install | sh",
+            "shutdown now",
+            "git reset --hard HEAD~3",
+            "git clean -fdx",
+        ] {
+            assert!(
+                model_candidate_rejection_reason(command, &config).is_some(),
+                "expected dangerous command: {command}"
+            );
+        }
+        for command in [
+            "cargo test --workspace",
+            "rm target.log",
+            "git reset --soft HEAD~1",
+        ] {
+            assert_eq!(
+                model_candidate_rejection_reason(command, &config),
+                None,
+                "unexpected model rejection: {command}"
             );
         }
     }

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -294,7 +294,7 @@ fn canonical_source(source: &str) -> &'static str {
         .replace('_', "-")
         .as_str()
     {
-        "history" | "deterministic-history" => "deterministic-history",
+        "history" | "event-history" | "deterministic-history" => "deterministic-history",
         "context" | "contextual-policy" => "contextual-policy",
         "local-model" => "local-model",
         "remote" | "remote-provider" => "remote-provider",

--- a/src/shell/soon.zsh
+++ b/src/shell/soon.zsh
@@ -24,12 +24,14 @@ if [[ -o interactive ]]; then
   typeset -g _soon_suggestion_event_id=''
   typeset -g _soon_suggestion_latency=''
   typeset -g _soon_suggestion_source=''
+  typeset -g _soon_suggestion_model_outcome=''
   typeset -g _soon_accepted_command=''
   typeset -g _soon_accepted_id=''
   typeset -g _soon_accepted_trigger=''
   typeset -g _soon_accepted_event_id=''
   typeset -g _soon_accepted_latency=''
   typeset -g _soon_accepted_source=''
+  typeset -g _soon_accepted_model_outcome=''
   typeset -g _soon_previous_ctrl_f=${${(z)$(bindkey '^F' 2>/dev/null)}[-1]}
   [[ -n $_soon_previous_ctrl_f ]] || _soon_previous_ctrl_f='.forward-char'
 
@@ -82,9 +84,17 @@ if [[ -o interactive ]]; then
       payload=${line#*$'\t'}
       if [[ $payload == *$'\t'* ]]; then
         _soon_suggestion_source=${payload%%$'\t'*}
-        _soon_suggestion=${payload#*$'\t'}
+        payload=${payload#*$'\t'}
+        if [[ $payload == *$'\t'* ]]; then
+          _soon_suggestion_model_outcome=${payload%%$'\t'*}
+          _soon_suggestion=${payload#*$'\t'}
+        else
+          _soon_suggestion_model_outcome=''
+          _soon_suggestion=$payload
+        fi
       else
         _soon_suggestion_source='deterministic-history'
+        _soon_suggestion_model_outcome=''
         _soon_suggestion=$payload
       fi
       _soon_suggestion_id="${EPOCHREALTIME//./}-$$-$RANDOM"
@@ -96,6 +106,7 @@ if [[ -o interactive ]]; then
       _soon_suggestion=''
       _soon_suggestion_id=''
       _soon_suggestion_source=''
+      _soon_suggestion_model_outcome=''
     fi
     zle -F $fd 2>/dev/null || true
     (( fd == _soon_fd )) && _soon_fd=-1
@@ -107,7 +118,7 @@ if [[ -o interactive ]]; then
     local outcome=$1
     [[ -n $_soon_suggestion_id && -n $_soon_suggestion ]] || return 0
 
-    _soon_emit_suggestion "$outcome" "$_soon_suggestion_id" "$_soon_suggestion_trigger" "$_soon_suggestion_event_id" "$_soon_suggestion_latency" "$_soon_suggestion_source" "$_soon_suggestion"
+    _soon_emit_suggestion "$outcome" "$_soon_suggestion_id" "$_soon_suggestion_trigger" "$_soon_suggestion_event_id" "$_soon_suggestion_latency" "$_soon_suggestion_source" "$_soon_suggestion" "$_soon_suggestion_model_outcome"
   }
 
   function _soon_emit_suggestion() {
@@ -118,6 +129,7 @@ if [[ -o interactive ]]; then
     local latency=$5
     local candidate_source=$6
     local command_text=$7
+    local model_outcome=$8
 
     local -a event_args=(
       events record-suggestion
@@ -129,6 +141,7 @@ if [[ -o interactive ]]; then
       --latency-ms "$latency"
     )
     [[ -n $command_event_id ]] && event_args+=(--command-event-id "$command_event_id")
+    [[ -n $model_outcome ]] && event_args+=(--model-outcome "$model_outcome")
     command soon "${event_args[@]}" >/dev/null 2>&1 &!
   }
 
@@ -144,6 +157,7 @@ if [[ -o interactive ]]; then
     _soon_cancel_prediction
     _soon_suggestion=''
     _soon_suggestion_source=''
+    _soon_suggestion_model_outcome=''
 
     if [[ -n $after ]]; then
       if (( exit_status == 0 )); then
@@ -200,7 +214,7 @@ if [[ -o interactive ]]; then
       _soon_record_suggestion dismissed
     fi
     if [[ -n $_soon_accepted_command && $1 == $_soon_accepted_command ]]; then
-      _soon_emit_suggestion executed "$_soon_accepted_id" "$_soon_accepted_trigger" "$_soon_accepted_event_id" "$_soon_accepted_latency" "$_soon_accepted_source" "$_soon_accepted_command"
+      _soon_emit_suggestion executed "$_soon_accepted_id" "$_soon_accepted_trigger" "$_soon_accepted_event_id" "$_soon_accepted_latency" "$_soon_accepted_source" "$_soon_accepted_command" "$_soon_accepted_model_outcome"
     fi
     _soon_accepted_command=''
     _soon_accepted_id=''
@@ -208,6 +222,7 @@ if [[ -o interactive ]]; then
     _soon_accepted_event_id=''
     _soon_accepted_latency=''
     _soon_accepted_source=''
+    _soon_accepted_model_outcome=''
     _soon_cancel_prediction
     _soon_suggestion=''
     _soon_suggestion_id=''
@@ -215,6 +230,7 @@ if [[ -o interactive ]]; then
     _soon_suggestion_event_id=''
     _soon_suggestion_latency=''
     _soon_suggestion_source=''
+    _soon_suggestion_model_outcome=''
     _soon_refresh_display
     local -a command_words=(${(z)1})
     if [[ ${command_words[1]:-} == soon ]] ||
@@ -261,10 +277,12 @@ if [[ -o interactive ]]; then
       _soon_accepted_event_id=$_soon_suggestion_event_id
       _soon_accepted_latency=$_soon_suggestion_latency
       _soon_accepted_source=$_soon_suggestion_source
+      _soon_accepted_model_outcome=$_soon_suggestion_model_outcome
       BUFFER=$_soon_suggestion
       CURSOR=${#BUFFER}
       _soon_suggestion=''
       _soon_suggestion_source=''
+      _soon_suggestion_model_outcome=''
       _soon_refresh_display
     else
       zle "$_soon_previous_ctrl_f"
@@ -282,6 +300,7 @@ if [[ -o interactive ]]; then
     zle -D _soon_apply_suggestion 2>/dev/null || true
     _soon_suggestion=''
     _soon_suggestion_source=''
+    _soon_suggestion_model_outcome=''
     _soon_highlight=''
   }
 

--- a/tests/model_prediction_cli.rs
+++ b/tests/model_prediction_cli.rs
@@ -1,0 +1,434 @@
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+static NEXT_HOME: AtomicU64 = AtomicU64::new(0);
+
+fn isolated_home() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    let sequence = NEXT_HOME.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!(
+        "soon-model-test-{}-{nonce}-{sequence}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).expect("create isolated home");
+    path
+}
+
+fn soon(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_soon"));
+    command
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local/share"));
+    command
+}
+
+fn set_config(home: &Path, key: &str, value: &str) {
+    let output = soon(home)
+        .args(["config", "set", key, value])
+        .output()
+        .expect("set config");
+    assert!(
+        output.status.success(),
+        "failed to set {key}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn configure_provider(home: &Path, listener: &TcpListener, provider: &str) {
+    set_config(home, "llm.provider", provider);
+    set_config(
+        home,
+        "llm.api_url",
+        &format!(
+            "http://{}",
+            listener.local_addr().expect("provider address")
+        ),
+    );
+    set_config(home, "llm.model", "mock-command-model");
+}
+
+fn record_command(home: &Path, id: &str, text: &str, exit_code: &str, previous_id: Option<&str>) {
+    let mut args = vec![
+        "events",
+        "record-command",
+        "--id",
+        id,
+        "--command",
+        text,
+        "--cwd",
+        "/tmp/soon-model-project",
+        "--started-at-ms",
+        "1000",
+        "--duration-ms",
+        "25",
+        "--exit-code",
+        exit_code,
+        "--shell",
+        "zsh",
+    ];
+    if let Some(previous_id) = previous_id {
+        args.extend(["--previous-id", previous_id]);
+    }
+    let output = soon(home)
+        .args(args)
+        .output()
+        .expect("record command event");
+    assert!(
+        output.status.success(),
+        "record failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn seed_repair_history(home: &Path) {
+    record_command(home, "failed-old", "cargo test", "1", None);
+    record_command(
+        home,
+        "repair-old",
+        "cargo test -- --nocapture",
+        "0",
+        Some("failed-old"),
+    );
+    record_command(
+        home,
+        "failed-current",
+        "cargo test",
+        "1",
+        Some("repair-old"),
+    );
+}
+
+fn spawn_provider(
+    listener: TcpListener,
+    commands: Vec<String>,
+    delay: Duration,
+) -> (thread::JoinHandle<()>, mpsc::Receiver<String>) {
+    let (request_tx, request_rx) = mpsc::channel();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept provider request");
+        let request = read_http_request(&mut stream);
+        let _ = request_tx.send(request);
+        if !delay.is_zero() {
+            thread::sleep(delay);
+        }
+        let model_content = serde_json::json!({"commands": commands}).to_string();
+        let body = serde_json::json!({
+            "choices": [{"message": {"content": model_content}}]
+        })
+        .to_string();
+        let _ = write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+    });
+    (server, request_rx)
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let read = stream.read(&mut chunk).expect("read provider request");
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&chunk[..read]);
+        let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        if request.len() >= header_end + 4 + content_length {
+            break;
+        }
+    }
+    String::from_utf8(request).expect("UTF-8 provider request")
+}
+
+fn append_legacy_sensitive_event(home: &Path, marker: &str) {
+    let path = home.join(".local/share/soon/events.jsonl");
+    fs::create_dir_all(path.parent().expect("event parent")).expect("create event parent");
+    let event = serde_json::json!({
+        "kind": "command",
+        "schema_version": 1,
+        "id": "legacy-sensitive",
+        "command": format!("export API_TOKEN={marker}"),
+        "cwd": "/tmp/soon-model-project",
+        "started_at_ms": 1,
+        "duration_ms": 1,
+        "exit_code": 0,
+        "shell": "zsh",
+        "previous_event_id": null
+    });
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("open event store");
+    writeln!(file, "{event}").expect("append legacy event");
+}
+
+#[test]
+fn model_sources_are_off_by_default_and_do_not_contact_the_provider() {
+    let home = isolated_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind provider");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking provider");
+    configure_provider(&home, &listener, "local");
+    seed_repair_history(&home);
+
+    let output = soon(&home)
+        .args([
+            "now",
+            "--raw",
+            "--include-source",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "1",
+            "--event-id",
+            "failed-current",
+            "--cwd",
+            "/tmp/soon-model-project",
+        ])
+        .output()
+        .expect("predict without model");
+
+    assert!(output.status.success(), "prediction failed");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("cargo test -- --nocapture"),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        matches!(listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock),
+        "default prediction contacted the provider"
+    );
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn explicit_generation_uses_filtered_context_and_never_executes_the_candidate() {
+    let home = isolated_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind provider");
+    configure_provider(&home, &listener, "openai-compatible");
+    let secret_marker = "history-secret-must-not-leave-device";
+    append_legacy_sensitive_event(&home, secret_marker);
+    record_command(&home, "safe", "cargo check", "0", None);
+    let marker = home.join("model-output-must-not-execute");
+    let generated = format!("touch {}", marker.display());
+    let (server, request_rx) = spawn_provider(listener, vec![generated.clone()], Duration::ZERO);
+
+    let output = soon(&home)
+        .args(["generate", "--raw", "--include-source"])
+        .output()
+        .expect("generate command");
+    let request = request_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider request");
+    server.join().expect("provider thread");
+
+    assert!(
+        output.status.success(),
+        "generation failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 output"),
+        format!("remote-provider\tsuccess\t{generated}\n")
+    );
+    assert!(request.contains("cargo check"), "{request}");
+    assert!(!request.contains(secret_marker), "{request}");
+    assert!(!request.contains("API_TOKEN"), "{request}");
+    assert!(!marker.exists(), "model candidate was executed");
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn opt_in_local_repair_flows_through_the_contextual_ranker() {
+    let home = isolated_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind provider");
+    configure_provider(&home, &listener, "local");
+    set_config(&home, "prediction.model_mode", "repair");
+    seed_repair_history(&home);
+    let model_repair = "cargo test --workspace".to_string();
+    let (server, _) = spawn_provider(listener, vec![model_repair.clone()], Duration::ZERO);
+
+    let output = soon(&home)
+        .args([
+            "now",
+            "--raw",
+            "--include-source",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "1",
+            "--event-id",
+            "failed-current",
+            "--cwd",
+            "/tmp/soon-model-project",
+        ])
+        .output()
+        .expect("model repair");
+    server.join().expect("provider thread");
+
+    assert!(
+        output.status.success(),
+        "repair failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 output"),
+        format!("local-model\tsuccess\t{model_repair}\n")
+    );
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn opt_in_rerank_can_reorder_only_local_history_candidates() {
+    let home = isolated_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind provider");
+    configure_provider(&home, &listener, "local");
+    set_config(&home, "prediction.model_mode", "rerank");
+    record_command(&home, "build-one", "cargo build", "0", None);
+    record_command(&home, "test", "cargo test", "0", Some("build-one"));
+    record_command(&home, "build-two", "cargo build", "0", Some("test"));
+    record_command(&home, "clippy", "cargo clippy", "0", Some("build-two"));
+    record_command(&home, "build-current", "cargo build", "0", Some("clippy"));
+    let (server, _) = spawn_provider(
+        listener,
+        vec!["cargo clippy".to_string(), "cargo test".to_string()],
+        Duration::ZERO,
+    );
+
+    let output = soon(&home)
+        .args([
+            "now",
+            "--raw",
+            "--include-source",
+            "--after",
+            "cargo build",
+            "--exit-code",
+            "0",
+            "--event-id",
+            "build-current",
+            "--cwd",
+            "/tmp/soon-model-project",
+        ])
+        .output()
+        .expect("model rerank");
+    server.join().expect("provider thread");
+
+    assert!(
+        output.status.success(),
+        "rerank failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 output"),
+        "local-model\tsuccess\tcargo clippy\n"
+    );
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn provider_timeout_falls_back_within_the_configured_deadline() {
+    let home = isolated_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind provider");
+    configure_provider(&home, &listener, "local");
+    set_config(&home, "prediction.model_mode", "repair");
+    set_config(&home, "prediction.model_timeout_ms", "40");
+    seed_repair_history(&home);
+    let (server, _) = spawn_provider(
+        listener,
+        vec!["cargo test --workspace".to_string()],
+        Duration::from_millis(200),
+    );
+
+    let started = Instant::now();
+    let output = soon(&home)
+        .args([
+            "now",
+            "--raw",
+            "--include-source",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "1",
+            "--event-id",
+            "failed-current",
+            "--cwd",
+            "/tmp/soon-model-project",
+        ])
+        .output()
+        .expect("timed model repair");
+    let elapsed = started.elapsed();
+    server.join().expect("provider thread");
+
+    assert!(output.status.success(), "fallback failed");
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 output"),
+        "deterministic-fallback\ttimeout\tcargo test -- --nocapture\n"
+    );
+    assert!(elapsed < Duration::from_millis(500), "elapsed={elapsed:?}");
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn dangerous_model_output_is_rejected_before_rendering() {
+    let home = isolated_home();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind provider");
+    configure_provider(&home, &listener, "local");
+    set_config(&home, "prediction.model_mode", "repair");
+    seed_repair_history(&home);
+    let (server, _) = spawn_provider(listener, vec!["rm -rf /".to_string()], Duration::ZERO);
+
+    let output = soon(&home)
+        .args([
+            "now",
+            "--raw",
+            "--include-source",
+            "--after",
+            "cargo test",
+            "--exit-code",
+            "1",
+            "--event-id",
+            "failed-current",
+            "--cwd",
+            "/tmp/soon-model-project",
+        ])
+        .output()
+        .expect("unsafe model repair");
+    server.join().expect("provider thread");
+
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 output");
+    assert!(output.status.success(), "fallback failed");
+    assert_eq!(
+        stdout,
+        "deterministic-fallback\tinvalid-output\tcargo test -- --nocapture\n"
+    );
+    assert!(!stdout.contains("rm -rf"), "{stdout}");
+    let _ = fs::remove_dir_all(home);
+}

--- a/tests/zsh_integration.zsh
+++ b/tests/zsh_integration.zsh
@@ -37,6 +37,7 @@ esac
 sleep 0.05
 prefix=''
 case " \$* " in
+  *' --exit-code 1 '*) prefix="local-model	success	" ;;
   *' --include-source '*) prefix="deterministic-history	" ;;
 esac
 case " \$* " in
@@ -167,6 +168,8 @@ wait_for_output 'SOON_PROMPT> '
 wait_for_output "touch $repair_file"
 wait_for_log '--command false'
 wait_for_log '--exit-code 1'
+wait_for_log '--candidate-source local-model'
+wait_for_log '--model-outcome success'
 
 zpty -w soon_shell 'print -r -- "SOON_STATUS:$?"'
 wait_for_output 'SOON_STATUS:1'


### PR DESCRIPTION
## Summary

- add default-off local and OpenAI-compatible Rerank, Repair, and explicit Generate candidate sources
- filter minimal provider context and untrusted output, enforce a hard deadline, and retain deterministic fallback
- attribute source/outcome through Zsh and replay, with mock-provider coverage and reproducible local-model evaluation

## Validation

- cargo test --locked (78 passed)
- cargo clippy --locked --all-targets -- -D warnings
- zsh tests/zsh_integration.zsh target/debug/soon
- uvx pre-commit run --all-files
- cargo package --locked --allow-dirty
- zsh tests/release_smoke.zsh target/debug/soon
- python3 tests/site_smoke.py
- local replay promotion gate: PASS (contextual top-1 35.5% vs 32.3%; p95 0.383 ms)
- Qwen2.5-Coder 0.5B Q4_K_M gate: 1/8 exact cold-start Repair, 676.2 ms p95; remains optional

Closes #17
Refs #4

## Summary by Sourcery

添加一个可选启用的、由模型驱动的候选层，用于重新排序、修复或显式生成 shell 命令建议，同时保持确定性的上下文策略为默认行为，并实施严格的隐私和安全约束。

New Features:
- 引入可配置的模型预测模式（off、rerank、repair、rerank-repair），提供针对每次请求的硬超时，并集成兼容 OpenAI 的提供方。
- 为上下文排序器增加对外部模型候选的支持，包括本地候选短名单生成以及用于非执行性建议的显式 `soon generate` CLI。
- 扩展 Zsh 集成和事件记录，以便在回放和分析中标注建议来源和模型结果。

Enhancements:
- 增强上下文排序，引入模型支持信号和模型顺序特征，同时保留确定性的并列决策和回退行为。
- 扩展隐私过滤，在排序或展示之前拒绝危险或不安全的模型生成命令，将模型输出视为不可信内容。
- 规范化提供方 URL、来源以及回放标签，以一致处理本地和远程的兼容 OpenAI 端点。

Documentation:
- 在新的指南中记录可选的模型候选来源、配置、提供方约定、截止时间、排序、回退机制，以及可复现的小型本地模型评估门。
- 更新 README 和上下文策略文档，说明混合预测引擎、模型模式、隐私保证以及新的 `soon generate` 命令。

Tests:
- 添加端到端 CLI 测试套件，使用兼容 OpenAI 的模拟 HTTP 服务器验证模型模式、超时、隐私过滤、危险输出处理，以及来源/结果标注。
- 添加针对模型配置校验、提供方 URL 规范化、带栅栏的 JSON 解析以及危险模型命令拒绝的单元测试。

Chores:
- 添加一个评估脚本，利用公共基准数据对比本地模型 Repair 性能与上下文基线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an opt-in model-backed candidate layer that can rerank, repair, or explicitly generate shell command suggestions while preserving the deterministic contextual policy as the default and enforcing strict privacy and safety constraints.

New Features:
- Introduce configurable model prediction modes (off, rerank, repair, rerank-repair) with a hard per-request timeout and OpenAI-compatible provider integration.
- Add support for external model candidates in the contextual ranker, including local shortlist generation and explicit `soon generate` CLI for non-executing suggestions.
- Extend Zsh integration and event recording to attribute suggestion source and model outcome for replay and analytics.

Enhancements:
- Augment contextual ranking with a model-support signal and model-order feature while retaining deterministic tie-breaking and fallback behavior.
- Expand privacy filtering to reject dangerous or unsafe model-generated commands before ranking or display, treating model output as untrusted.
- Normalize provider URLs, sources, and replay labels to handle local and remote OpenAI-compatible endpoints consistently.

Documentation:
- Document optional model candidate sources, configuration, provider contract, deadlines, ranking, fallback, and a reproducible small local-model evaluation gate in new guides.
- Update README and contextual policy docs to describe the hybrid prediction engine, model modes, privacy guarantees, and the new `soon generate` command.

Tests:
- Add an end-to-end CLI test suite using a mock OpenAI-compatible HTTP server to validate model modes, timeouts, privacy filtering, dangerous output handling, and source/outcome attribution.
- Add unit tests for model configuration validation, provider URL normalization, fenced JSON parsing, and dangerous-model-command rejection.

Chores:
- Add an evaluation script to benchmark local-model Repair performance against the contextual baseline using public fixtures.

</details>