### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to soon are documented here.
 
 ## Unreleased
 
+## 0.5.0 - 2026-07-31
+
+soon 0.5.0 makes the measured contextual policy the local default and adds an
+optional model-backed candidate layer without putting inference or network
+access on the ordinary prediction path. Suggestions remain editable text and
+are never executed automatically.
+
 ### Added
 
 - Added a contextual full-command ranker with separate candidate-source
@@ -17,6 +24,8 @@ All notable changes to soon are documented here.
   filtered, model output is treated as untrusted, deadlines fall back to the
   deterministic policy, and Zsh/replay retain source and outcome attribution
   ([#17](https://github.com/HsiangNianian/soon/issues/17)).
+
+[Full diff](https://github.com/HsiangNianian/soon/compare/v0.4.2...v0.5.0)
 
 ## 0.4.2 - 2026-07-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "soon"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soon"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Local-first prediction for your next full shell command"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A local-first terminal agent that predicts, repairs, and suggests your next full
 [![CI](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml/badge.svg)](https://github.com/HsiangNianian/soon/actions/workflows/proof-pr.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-[Website](https://soon.hydroroll.team) · [v0.4.2 Zsh parser patch](https://github.com/HsiangNianian/soon/releases/tag/v0.4.2) · [Roadmap](https://github.com/users/HsiangNianian/projects/7)
+[Website](https://soon.hydroroll.team) · [v0.5.0 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/releases/tag/v0.5.0) · [Roadmap](https://github.com/users/HsiangNianian/projects/7)
 
 </div>
 
-> **Beta status:** v0.4.2 ships the opt-in Zsh ghost-suggestion loop, a privacy-safe adoption report, and correct handling for compound commands in Zsh history. Interactive integration is supported on native Linux and macOS; other shells and packaged platforms remain experimental unless listed in the [release contract](RELEASING.md).
+> **Beta status:** v0.5.0 ships the opt-in Zsh ghost-suggestion loop, the measured contextual policy as the local default, and optional model-backed Rerank, Repair, and explicit Generate paths. Interactive integration is supported on native Linux and macOS; other shells and packaged platforms remain experimental unless listed in the [release contract](RELEASING.md).
 
 <a href="https://soon.hydroroll.team">
   <img src="www/assets/soon-demo.svg" alt="An 18-second terminal demo: a failed Git command triggers a local Repair suggestion, Ctrl-F accepts it into the editable buffer, and the user decides when to execute it.">
@@ -23,7 +23,7 @@ A local-first terminal agent that predicts, repairs, and suggests your next full
 
 ## Try the beta
 
-Install the same v0.4.2 release through Cargo or PyPI:
+Install the same v0.5.0 release through Cargo or PyPI:
 
 ```bash
 cargo install soon
@@ -40,7 +40,7 @@ At an empty prompt, soon computes in the background and renders one dim full-com
 
 The default prediction path uses local history, not a model or network service. It can choose a Next-step suggestion after success, a Repair suggestion after failure, or predict on demand when you run `soon`.
 
-> **v0.5 development:** the source tree defaults to the local contextual policy after it passed the replay promotion gate. The published v0.4.2 package still uses the deterministic baseline.
+The v0.5.0 package defaults to the local contextual policy after it passed the replay promotion gate. Model-backed candidates remain disabled unless explicitly configured or requested with `soon generate`.
 
 ## The idea
 
@@ -124,7 +124,7 @@ soon --shell zsh
 
 The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and tcsh history. Parsing a format does not mean interactive integration for that shell is complete.
 
-## What v0.4 ships
+## What v0.5 ships
 
 | Shipped surface | Release evidence |
 |---|---|
@@ -132,6 +132,7 @@ The current source can parse Bash, Zsh, Fish, Nushell, Elvish, PowerShell, and t
 | Manual, successful-command Next-step, and failed-command Repair triggers | Native Linux and macOS lifecycle regression coverage |
 | Retained events plus chronological quality and latency replay | Deterministic fixture with a 20 ms Zsh p95 budget |
 | Sensitive-command filters plus idempotent Zsh history import | Documented privacy behavior and aggregate-only inspection |
+| Contextual ranking plus opt-in model candidate sources | Baseline comparison, mock providers, and a documented 0.5B evaluation |
 
 The implementation plan lives in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). Work is tracked in the public [Personal Terminal Agent Project](https://github.com/users/HsiangNianian/projects/7).
 
@@ -145,7 +146,7 @@ Optional local and OpenAI-compatible sources can rerank safe history candidates,
 
 The [small local model gate](docs/model-evaluation.md) tested Qwen2.5-Coder 0.5B Q4_K_M on an Intel Mac. It added one exact cold-start Repair across eight public fixtures at 676.2 ms p95, which was enough to validate the optional path but not enough quality evidence to enable it by default.
 
-The v0.5 source promotes contextual after it improved exact top-1 without reducing coverage or exceeding the 20 ms p95 budget in both the deterministic fixture and a local aggregate replay. `v0.4-baseline` remains an explicit offline fallback.
+The v0.5.0 release promotes contextual after it improved exact top-1 without reducing coverage or exceeding the 20 ms p95 budget in both the deterministic fixture and a local aggregate replay. `v0.4-baseline` remains an explicit offline fallback.
 
 ## Agent roadmap
 
@@ -153,7 +154,7 @@ The [v0.4 Local Agent MVP](https://github.com/HsiangNianian/soon/milestone/1) co
 
 The closed [v0.4.1 Adoption Sprint](https://github.com/HsiangNianian/soon/milestone/3) added the public demo, launch assets, and privacy-safe report. The planned ten-user pilot and final timed launch measurements were explicitly closed as not planned rather than reported as completed.
 
-The [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) promotes the contextual probabilistic ranker from [#16](https://github.com/HsiangNianian/soon/issues/16) and adds the opt-in local-model/OpenAI-compatible layer from [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
+The completed [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) promotes the contextual probabilistic ranker from [#16](https://github.com/HsiangNianian/soon/issues/16) and adds the opt-in local-model/OpenAI-compatible layer from [#17](https://github.com/HsiangNianian/soon/issues/17). Model output is never required for the default hot path.
 
 ## Privacy
 
@@ -290,7 +291,7 @@ soon update             Check the configured release channel
 
 ## Contributing
 
-Start with [RFC #4](https://github.com/HsiangNianian/soon/issues/4), then choose an open issue from the [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2). The contextual ranker is tracked in [#16](https://github.com/HsiangNianian/soon/issues/16), and the opt-in model candidate layer is tracked in [#17](https://github.com/HsiangNianian/soon/issues/17).
+The accepted direction is recorded in [RFC #4](https://github.com/HsiangNianian/soon/issues/4). The completed [v0.5 Hybrid Prediction Engine](https://github.com/HsiangNianian/soon/milestone/2) delivered the contextual ranker in [#16](https://github.com/HsiangNianian/soon/issues/16) and the opt-in model candidate layer in [#17](https://github.com/HsiangNianian/soon/issues/17).
 
 For local verification:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 # Releasing soon
 
-## v0.4 beta support contract
+## v0.5 beta support contract
 
 The interactive beta is supported on Zsh on native Linux and macOS runners. The on-demand CLI and Python wheels are built for the targets listed in `.github/workflows/release.yml`, but shell parsers other than Zsh do not yet imply supported interactive integration.
 
-| Channel | v0.4 beta status | Update source |
+| Channel | v0.5 beta status | Update source |
 |---|---|---|
 | Cargo package `soon` | Supported | crates.io package metadata |
 | PyPI package `soon-bin` | Supported | PyPI package metadata |

--- a/docs/contextual-policy.md
+++ b/docs/contextual-policy.md
@@ -1,13 +1,13 @@
 # Contextual prediction policy
 
-The contextual policy is the local-only default in the v0.5 development source after passing the replay promotion gate. Switch between it and the v0.4 fallback with:
+The contextual policy is the local-only default in v0.5.0 after passing the replay promotion gate. Switch between it and the v0.4 fallback with:
 
 ```bash
 soon config set prediction.policy contextual
 soon config set prediction.policy v0.4-baseline
 ```
 
-The published v0.4.2 package still defaults to `v0.4-baseline`. Run `soon replay` after installing a v0.5 build; it evaluates both policies on the same chronological prefixes without exposing command text.
+Run `soon replay` after installing v0.5.0; it evaluates the contextual default and `v0.4-baseline` on the same chronological prefixes without exposing command text.
 
 ## Boundaries
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -22,8 +22,8 @@ impl std::fmt::Display for InstallChannel {
         match self {
             InstallChannel::Cargo => write!(f, "cargo"),
             InstallChannel::Pip => write!(f, "pip"),
-            InstallChannel::Aur => write!(f, "AUR (unsupported for v0.4 beta)"),
-            InstallChannel::Binary => write!(f, "standalone binary (unsupported for v0.4 beta)"),
+            InstallChannel::Aur => write!(f, "AUR (unsupported beta channel)"),
+            InstallChannel::Binary => write!(f, "standalone binary (unsupported beta channel)"),
             InstallChannel::Unknown => write!(f, "unknown"),
         }
     }
@@ -65,7 +65,7 @@ fn latest_version(channel: &InstallChannel) -> Result<String, String> {
         InstallChannel::Pip => PYPI_API,
         InstallChannel::Aur | InstallChannel::Binary => {
             return Err(format!(
-                "{channel} is not a supported v0.4 beta channel; use cargo install soon or pip install soon-bin"
+                "{channel} is not a supported beta channel; use cargo install soon or pip install soon-bin"
             ));
         }
         InstallChannel::Unknown => {
@@ -138,7 +138,7 @@ fn do_update(channel: &InstallChannel) -> Result<(), String> {
         }
         InstallChannel::Aur | InstallChannel::Binary => {
             return Err(format!(
-                "{channel} is not a supported v0.4 beta channel; no update was attempted"
+                "{channel} is not a supported beta channel; no update was attempted"
             ));
         }
         InstallChannel::Unknown => {
@@ -258,8 +258,8 @@ mod tests {
     #[test]
     fn unsupported_channels_have_no_release_lookup() {
         let error = latest_version(&InstallChannel::Aur).expect_err("AUR must stay disabled");
-        assert!(error.contains("not a supported v0.4 beta channel"));
+        assert!(error.contains("not a supported beta channel"));
         let error = latest_version(&InstallChannel::Binary).expect_err("binary must stay disabled");
-        assert!(error.contains("not a supported v0.4 beta channel"));
+        assert!(error.contains("not a supported beta channel"));
     }
 }

--- a/tests/site_smoke.py
+++ b/tests/site_smoke.py
@@ -73,7 +73,7 @@ def main() -> None:
     assert "cargo install soon" in html
     assert "python -m pip install soon-bin" in html
     assert 'eval "$(soon init zsh)"' in html
-    assert "v0.4.2" in html
+    assert "v0.5.0" in html
     assert "No automatic execution" in html
 
     for attribute, reference in parser.references:

--- a/www/index.html
+++ b/www/index.html
@@ -30,7 +30,7 @@
     <main id="main">
       <section class="hero" aria-labelledby="hero-title">
         <div class="hero-copy">
-          <p class="eyebrow">v0.4.2 beta · Zsh · local by default</p>
+          <p class="eyebrow">v0.5.0 beta · Zsh · local by default</p>
           <h1 id="hero-title">Your terminal already knows what comes next.</h1>
           <p class="lede">
             soon learns recurring command transitions, then places one complete
@@ -39,8 +39,8 @@
 
           <div class="hero-actions">
             <a class="button button-primary" href="#install">Install the beta</a>
-            <a class="button button-secondary" href="https://github.com/HsiangNianian/soon/releases/tag/v0.4.2">
-              Read the v0.4.2 release
+            <a class="button button-secondary" href="https://github.com/HsiangNianian/soon/releases/tag/v0.5.0">
+              Read the v0.5.0 release
             </a>
           </div>
 
@@ -108,7 +108,7 @@
           <p class="eyebrow">Three commands</p>
           <h2 id="install-title">Meet the next prompt.</h2>
           <p>
-            Install the same v0.4.2 release from Cargo or PyPI, then opt in for
+            Install the same v0.5.0 release from Cargo or PyPI, then opt in for
             the current Zsh session.
           </p>
         </div>


### PR DESCRIPTION
## Summary

- bump the shared Cargo/PyPI version source from 0.4.2 to 0.5.0
- finalize the v0.5 changelog for the contextual default and opt-in model candidate layer
- update README, release contract, CLI wording, and website from development/v0.4 language to the v0.5.0 release surface

## Validation

- cargo test --locked (78 passed)
- cargo clippy --locked --all-targets -- -D warnings
- cargo package --locked --allow-dirty
- zsh tests/release_smoke.zsh target/debug/soon
- python3 tests/site_smoke.py
- uvx pre-commit run --all-files
- target/debug/soon --version reports 0.5.0

Release scope: #4, #16, #17

## Summary by Sourcery

通过更新版本，并记录上下文默认策略和可选的模型支持预测层，为 0.5.0 测试版发布做准备。

增强功能：
- 明确 CLI 在不支持的更新通道上的提示信息，使其与具体版本无关。
- 记录在 v0.5.0 中，上下文预测策略已成为默认策略，并将 v0.4-baseline 作为明确的回退选项。

构建：
- 将 Cargo 包版本从 0.4.2 提升到 0.5.0，以支持新版本发布。

文档：
- 更新 README、上下文策略文档、更新日志、发布约定以及网站文案，以描述 v0.5.0 测试版，其上下文默认策略，以及可选的模型支持特性。

测试：
- 调整站点冒烟测试的预期结果，以匹配 v0.5.0 网站内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the 0.5.0 beta release by updating versions and documenting the contextual default policy and optional model-backed prediction layer.

Enhancements:
- Clarify CLI messaging around unsupported update channels to be version-agnostic.
- Document that the contextual prediction policy is now the default in v0.5.0 with v0.4-baseline as an explicit fallback.

Build:
- Bump the Cargo package version from 0.4.2 to 0.5.0 for the new release.

Documentation:
- Refresh README, contextual-policy docs, changelog, release contract, and website copy to describe the v0.5.0 beta, its contextual default, and opt-in model-backed features.

Tests:
- Adjust site smoke test expectations to match the v0.5.0 website content.

</details>